### PR TITLE
Implement basic item creation from simc profile string line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Simc Profile Parser
-Library to parse items in the simc import format into functional objects.
+![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/github/MechanicalPriest/SimcProfileParser?branch=master&svg=true)
+
+A library to parse items in the simc import format into functional objects.
 
 ## Support
 For bugs please search [issues](https://github.com/MechanicalPriest/SimcProfileParser/issues) 

--- a/SimcProfileParser.Tests/DataSync/CacheServiceTests.cs
+++ b/SimcProfileParser.Tests/DataSync/CacheServiceTests.cs
@@ -36,39 +36,22 @@ namespace SimcProfileParser.Tests.DataSync
             CacheService cache = new CacheService(null, null);
             var configuration = new CacheFileConfiguration()
             {
-                LocalParsedFile = "ItemData.json",
-                ParsedFileType = SimcParsedFileType.ItemDataNew,
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
                 RawFiles = new Dictionary<string, string>()
                 {
-                    { "ItemData.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/item_data.inc" }
+                    { "ScaleData.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/sc_scale_data.inc" }
                 }
             };
+            var filePath = Path.Combine(cache.BaseFileDirectory, "ScaleData.raw");
 
             // Act
-            var data = cache.GetRawFileContents(configuration, "ItemData.raw");
+            var data = cache.GetRawFileContents(configuration, "ScaleData.raw");
 
             // Assert
             DirectoryAssert.Exists(cache.BaseFileDirectory);
-            FileAssert.Exists(Path.Combine(cache.BaseFileDirectory, "ItemData.raw"));
+            FileAssert.Exists(filePath);
             Assert.NotNull(data);
-        }
-
-        [Test]
-        public void CS_Downloads_File_If_Changed()
-        {
-
-        }
-
-        [Test]
-        public void CS_Downloads_File_If_NotExists()
-        {
-
-        }
-
-        [Test]
-        public void CS_Skips_Download_If_File_Not_Changed_And_Exists()
-        {
-
         }
 
         [Test]
@@ -152,14 +135,6 @@ namespace SimcProfileParser.Tests.DataSync
             Assert.IsNotNull(data);
             FileAssert.Exists(Path.Combine(cache.BaseFileDirectory, "FileDownloadCache.json"));
             Assert.AreEqual(fileContents, data);
-        }
-
-        [OneTimeTearDown]
-        public void TearDownOnce()
-        {
-            ICacheService cache = new CacheService(null, null);
-            if (Directory.Exists(cache.BaseFileDirectory))
-                Directory.Delete(cache.BaseFileDirectory, true);
         }
     }
 }

--- a/SimcProfileParser.Tests/DataSync/RawDataExtractionServiceTests.cs
+++ b/SimcProfileParser.Tests/DataSync/RawDataExtractionServiceTests.cs
@@ -1,150 +1,150 @@
-﻿using Newtonsoft.Json;
-using NUnit.Framework;
-using SimcProfileParser.DataSync;
-using SimcProfileParser.Interfaces.DataSync;
-using SimcProfileParser.Model.RawData;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿//using Newtonsoft.Json;
+//using NUnit.Framework;
+//using SimcProfileParser.DataSync;
+//using SimcProfileParser.Interfaces.DataSync;
+//using SimcProfileParser.Model.RawData;
+//using System;
+//using System.Collections.Generic;
+//using System.IO;
+//using System.Text;
 
-namespace SimcProfileParser.Tests.DataSync
-{
-    [TestFixture]
-    public class RawDataExtractionServiceTests
-    {
-        [Test]
-        public void RDE_Generates_CR_Multi()
-        {
-            // Arrange
-            ICacheService cacheService = new CacheService();
-            IRawDataExtractionService rawDataExtractionService = 
-                new RawDataExtractionService(cacheService);
+//namespace SimcProfileParser.Tests.DataSync
+//{
+//    [TestFixture]
+//    public class RawDataExtractionServiceTests
+//    {
+//        [Test]
+//        public void RDE_Generates_CR_Multi()
+//        {
+//            // Arrange
+//            ICacheService cacheService = new CacheService(null);
+//            IRawDataExtractionService rawDataExtractionService = 
+//                new RawDataExtractionService(cacheService);
 
-            var filepath = Path.Combine(cacheService.BaseFileDirectory, "CombatRatingMultipliers.json");
+//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "CombatRatingMultipliers.json");
 
-            // Act
-            rawDataExtractionService.GenerateCombatRatingMultipliers();
-            var rawData = File.ReadAllText(filepath);
-            var data = JsonConvert.DeserializeObject<float[][]>(rawData);
+//            // Act
+//            rawDataExtractionService.GenerateCombatRatingMultipliers();
+//            var rawData = File.ReadAllText(filepath);
+//            var data = JsonConvert.DeserializeObject<float[][]>(rawData);
 
-            // Assert
-            FileAssert.Exists(filepath);
-            Assert.IsNotNull(data);
-            Assert.AreEqual(4, data.Length);
-            Assert.AreEqual(1300, data[0].Length);
-        }
+//            // Assert
+//            FileAssert.Exists(filepath);
+//            Assert.IsNotNull(data);
+//            Assert.AreEqual(4, data.Length);
+//            Assert.AreEqual(1300, data[0].Length);
+//        }
 
-        [Test]
-        public void RDE_Generates_Stam_Multi()
-        {
-            // Arrange
-            ICacheService cacheService = new CacheService();
-            IRawDataExtractionService rawDataExtractionService =
-                new RawDataExtractionService(cacheService);
+//        [Test]
+//        public void RDE_Generates_Stam_Multi()
+//        {
+//            // Arrange
+//            ICacheService cacheService = new CacheService(null);
+//            IRawDataExtractionService rawDataExtractionService =
+//                new RawDataExtractionService(cacheService);
 
-            var filepath = Path.Combine(cacheService.BaseFileDirectory, "StaminaMultipliers.json");
+//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "StaminaMultipliers.json");
 
-            // Act
-            rawDataExtractionService.GenerateStaminaMultipliers();
-            var rawData = File.ReadAllText(filepath);
-            var data = JsonConvert.DeserializeObject<float[][]>(rawData);
+//            // Act
+//            rawDataExtractionService.GenerateStaminaMultipliers();
+//            var rawData = File.ReadAllText(filepath);
+//            var data = JsonConvert.DeserializeObject<float[][]>(rawData);
 
-            // Assert
-            FileAssert.Exists(filepath);
-            Assert.IsNotNull(data);
-            Assert.AreEqual(4, data.Length);
-            Assert.AreEqual(1300, data[0].Length);
-        }
+//            // Assert
+//            FileAssert.Exists(filepath);
+//            Assert.IsNotNull(data);
+//            Assert.AreEqual(4, data.Length);
+//            Assert.AreEqual(1300, data[0].Length);
+//        }
 
-        [Test]
-        public void RDE_Generates_ItemData()
-        {
-            // Arrange
-            ICacheService cacheService = new CacheService();
-            IRawDataExtractionService rawDataExtractionService =
-                new RawDataExtractionService(cacheService);
+//        [Test]
+//        public void RDE_Generates_ItemData()
+//        {
+//            // Arrange
+//            ICacheService cacheService = new CacheService(null);
+//            IRawDataExtractionService rawDataExtractionService =
+//                new RawDataExtractionService(cacheService);
 
-            var filepath = Path.Combine(cacheService.BaseFileDirectory, "ItemData.json");
+//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "ItemData.json");
 
-            // Act
-            rawDataExtractionService.GenerateItemData();
-            var rawData = File.ReadAllText(filepath);
+//            // Act
+//            rawDataExtractionService.GenerateItemData();
+//            var rawData = File.ReadAllText(filepath);
 
-            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
+//            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
 
-            // Assert
-            // TODO: Add tests for each field of each item in a new test class? Against known items with valid values
-            FileAssert.Exists(filepath);
-            Assert.IsNotNull(data);
-            Assert.LessOrEqual(68475, data.Count);
-        }
+//            // Assert
+//            // TODO: Add tests for each field of each item in a new test class? Against known items with valid values
+//            FileAssert.Exists(filepath);
+//            Assert.IsNotNull(data);
+//            Assert.LessOrEqual(68475, data.Count);
+//        }
 
-        [Test]
-        public void RDE_Generates_RandomPropData()
-        {
-            // Arrange
-            ICacheService cacheService = new CacheService();
-            IRawDataExtractionService rawDataExtractionService =
-                new RawDataExtractionService(cacheService);
+//        [Test]
+//        public void RDE_Generates_RandomPropData()
+//        {
+//            // Arrange
+//            ICacheService cacheService = new CacheService(null);
+//            IRawDataExtractionService rawDataExtractionService =
+//                new RawDataExtractionService(cacheService);
 
-            var filepath = Path.Combine(cacheService.BaseFileDirectory, "RandomPropData.json");
+//            var rawFilepath = Path.Combine(cacheService.BaseFileDirectory, "RandomPropData.raw");
 
-            // Act
-            rawDataExtractionService.GenerateRandomPropData();
-            var rawData = File.ReadAllText(filepath);
+//            // Act
+//            var rawData = File.ReadAllText(rawFilepath);
+//            rawDataExtractionService.GenerateRandomPropData(new Dictionary<string, string>()
+//            { 
+//                {"RandomPropData.raw", rawData }
+//            });
 
-            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
+//            // Assert
+//            //Assert.IsNotNull(data);
+//            //Assert.AreEqual(1300, data.Count);
+//        }
 
-            // Assert
-            FileAssert.Exists(filepath);
-            Assert.IsNotNull(data);
-            Assert.AreEqual(1300, data.Count);
-        }
+//        [Test]
+//        public void RDE_Generates_SpellData()
+//        {
+//            // Arrange
+//            ICacheService cacheService = new CacheService(null);
+//            IRawDataExtractionService rawDataExtractionService =
+//                new RawDataExtractionService(cacheService);
 
-        [Test]
-        public void RDE_Generates_SpellData()
-        {
-            // Arrange
-            ICacheService cacheService = new CacheService();
-            IRawDataExtractionService rawDataExtractionService =
-                new RawDataExtractionService(cacheService);
+//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "SpellData.json");
 
-            var filepath = Path.Combine(cacheService.BaseFileDirectory, "SpellData.json");
+//            // Act
+//            rawDataExtractionService.GenerateSpellData();
+//            var rawData = File.ReadAllText(filepath);
 
-            // Act
-            rawDataExtractionService.GenerateSpellData();
-            var rawData = File.ReadAllText(filepath);
+//            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
 
-            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
+//            // Assert
+//            // TODO: Add tests for each field of each spell in a new test class? Against known items with valid values
+//            FileAssert.Exists(filepath);
+//            Assert.IsNotNull(data);
+//            Assert.LessOrEqual(16945, data.Count);
+//        }
 
-            // Assert
-            // TODO: Add tests for each field of each spell in a new test class? Against known items with valid values
-            FileAssert.Exists(filepath);
-            Assert.IsNotNull(data);
-            Assert.LessOrEqual(16945, data.Count);
-        }
+//        [Test]
+//        public void RDE_Generates_ItemBonuses()
+//        {
+//            // Arrange
+//            ICacheService cacheService = new CacheService(null);
+//            IRawDataExtractionService rawDataExtractionService =
+//                new RawDataExtractionService(cacheService);
 
-        [Test]
-        public void RDE_Generates_ItemBonuses()
-        {
-            // Arrange
-            ICacheService cacheService = new CacheService();
-            IRawDataExtractionService rawDataExtractionService =
-                new RawDataExtractionService(cacheService);
+//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "ItemBonusData.json");
 
-            var filepath = Path.Combine(cacheService.BaseFileDirectory, "ItemBonusData.json");
+//            // Act
+//            rawDataExtractionService.GenerateItemBonusData();
+//            var rawData = File.ReadAllText(filepath);
 
-            // Act
-            rawDataExtractionService.GenerateItemBonusData();
-            var rawData = File.ReadAllText(filepath);
+//            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
 
-            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
-
-            // Assert
-            FileAssert.Exists(filepath);
-            Assert.IsNotNull(data);
-            Assert.LessOrEqual(9813, data.Count);
-        }
-    }
-}
+//            // Assert
+//            FileAssert.Exists(filepath);
+//            Assert.IsNotNull(data);
+//            Assert.LessOrEqual(9813, data.Count);
+//        }
+//    }
+//}

--- a/SimcProfileParser.Tests/DataSync/RawDataExtractionServiceTests.cs
+++ b/SimcProfileParser.Tests/DataSync/RawDataExtractionServiceTests.cs
@@ -1,150 +1,200 @@
-﻿//using Newtonsoft.Json;
-//using NUnit.Framework;
-//using SimcProfileParser.DataSync;
-//using SimcProfileParser.Interfaces.DataSync;
-//using SimcProfileParser.Model.RawData;
-//using System;
-//using System.Collections.Generic;
-//using System.IO;
-//using System.Text;
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
+using SimcProfileParser.DataSync;
+using SimcProfileParser.Interfaces.DataSync;
+using SimcProfileParser.Model.RawData;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
 
-//namespace SimcProfileParser.Tests.DataSync
-//{
-//    [TestFixture]
-//    public class RawDataExtractionServiceTests
-//    {
-//        [Test]
-//        public void RDE_Generates_CR_Multi()
-//        {
-//            // Arrange
-//            ICacheService cacheService = new CacheService(null);
-//            IRawDataExtractionService rawDataExtractionService = 
-//                new RawDataExtractionService(cacheService);
+namespace SimcProfileParser.Tests.DataSync
+{
+    [TestFixture]
+    public class RawDataExtractionServiceTests
+    {
+        [Test]
+        public void RDE_Generates_CR_Multi()
+        {
+            // Arrange
+            RawDataExtractionService rawDataExtractionService =
+                new RawDataExtractionService(null);
 
-//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "CombatRatingMultipliers.json");
+            var incomingRawData = new Dictionary<string, string>()
+            {
+                { "ScaleData.raw", @"__combat_ratings_mult_by_ilvl[][1300] = { { 0.1, 0.2, }, { 0.3, 0.4, }, { 0.5, 0.6, }, { 0.7, 0.8, }, };" }
+            };
 
-//            // Act
-//            rawDataExtractionService.GenerateCombatRatingMultipliers();
-//            var rawData = File.ReadAllText(filepath);
-//            var data = JsonConvert.DeserializeObject<float[][]>(rawData);
+            // Act
+            var result = rawDataExtractionService.GenerateCombatRatingMultipliers(incomingRawData);
 
-//            // Assert
-//            FileAssert.Exists(filepath);
-//            Assert.IsNotNull(data);
-//            Assert.AreEqual(4, data.Length);
-//            Assert.AreEqual(1300, data[0].Length);
-//        }
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(4, result.Length);
+            Assert.AreEqual(1300, result[0].Length);
+            Assert.AreEqual(0.1f, result[0][0]);
+            Assert.AreEqual(0.2f, result[0][1]);
+            Assert.AreEqual(0.3f, result[1][0]);
+            Assert.AreEqual(0.4f, result[1][1]);
+            Assert.AreEqual(0.5f, result[2][0]);
+            Assert.AreEqual(0.6f, result[2][1]);
+            Assert.AreEqual(0.7f, result[3][0]);
+            Assert.AreEqual(0.8f, result[3][1]);
+        }
 
-//        [Test]
-//        public void RDE_Generates_Stam_Multi()
-//        {
-//            // Arrange
-//            ICacheService cacheService = new CacheService(null);
-//            IRawDataExtractionService rawDataExtractionService =
-//                new RawDataExtractionService(cacheService);
+        [Test]
+        public void RDE_Generates_Stam_Multi()
+        {
+            // Arrange
+            RawDataExtractionService rawDataExtractionService =
+                new RawDataExtractionService(null);
 
-//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "StaminaMultipliers.json");
+            var incomingRawData = new Dictionary<string, string>()
+            {
+                { "ScaleData.raw", @"__stamina_mult_by_ilvl[][1300] = { { 0.1, 0.2, }, { 0.3, 0.4, }, { 0.5, 0.6, }, { 0.7, 0.8, }, };" }
+            };
 
-//            // Act
-//            rawDataExtractionService.GenerateStaminaMultipliers();
-//            var rawData = File.ReadAllText(filepath);
-//            var data = JsonConvert.DeserializeObject<float[][]>(rawData);
+            // Act
+            var result = rawDataExtractionService.GenerateStaminaMultipliers(incomingRawData);
 
-//            // Assert
-//            FileAssert.Exists(filepath);
-//            Assert.IsNotNull(data);
-//            Assert.AreEqual(4, data.Length);
-//            Assert.AreEqual(1300, data[0].Length);
-//        }
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(4, result.Length);
+            Assert.AreEqual(1300, result[0].Length);
+            Assert.AreEqual(0.1f, result[0][0]);
+            Assert.AreEqual(0.2f, result[0][1]);
+            Assert.AreEqual(0.3f, result[1][0]);
+            Assert.AreEqual(0.4f, result[1][1]);
+            Assert.AreEqual(0.5f, result[2][0]);
+            Assert.AreEqual(0.6f, result[2][1]);
+            Assert.AreEqual(0.7f, result[3][0]);
+            Assert.AreEqual(0.8f, result[3][1]);
+        }
 
-//        [Test]
-//        public void RDE_Generates_ItemData()
-//        {
-//            // Arrange
-//            ICacheService cacheService = new CacheService(null);
-//            IRawDataExtractionService rawDataExtractionService =
-//                new RawDataExtractionService(cacheService);
+        [Test]
+        public void RDE_Generates_ItemData()
+        {
+            // Arrange
+            RawDataExtractionService rawDataExtractionService =
+                new RawDataExtractionService(null);
 
-//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "ItemData.json");
+            var incomingRawData = new Dictionary<string, string>()
+            {
+                { "ItemData.raw", @"{ 32,  6667, 0.000000 },
+                     { ""Gladiator's Medallion"", 184268, 0x00081000, 0x00006000, 0x00, 1, 35, 0, 0, 0, 12, 4, 0, 1, 0, 0.000000, 0.000000, &__item_stats_data[0], 1, 0xffff, 0xaa2aaaaa4e0ab3b2, { 0, 0, 0 }, 0, 0, 1458, 0, 0 }," },
+                { "ItemEffect.raw", @"  { 135983,  42292, 184268,   0,   0, 1182,  120000,  120000 }, // PvP Trinket" }
+            };
 
-//            // Act
-//            rawDataExtractionService.GenerateItemData();
-//            var rawData = File.ReadAllText(filepath);
+            // Act
+            var result = rawDataExtractionService.GenerateItemData(incomingRawData);
+            var resultTooHigh = rawDataExtractionService.GenerateItemData(incomingRawData, 0, 184267);
+            var resultTooLow = rawDataExtractionService.GenerateItemData(incomingRawData, 184269);
 
-//            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
+            // Assert
+            // TODO: Add tests for each field of each item in a new test class? Against known items with valid values
+            Assert.IsNotNull(result);
+            Assert.NotZero(result.Count);
+            Assert.NotZero(result.FirstOrDefault().ItemMods.Count);
+            Assert.NotZero(result.FirstOrDefault().ItemEffects.Count);
 
-//            // Assert
-//            // TODO: Add tests for each field of each item in a new test class? Against known items with valid values
-//            FileAssert.Exists(filepath);
-//            Assert.IsNotNull(data);
-//            Assert.LessOrEqual(68475, data.Count);
-//        }
+            Assert.IsNotNull(resultTooHigh);
+            Assert.Zero(resultTooHigh.Count);
 
-//        [Test]
-//        public void RDE_Generates_RandomPropData()
-//        {
-//            // Arrange
-//            ICacheService cacheService = new CacheService(null);
-//            IRawDataExtractionService rawDataExtractionService =
-//                new RawDataExtractionService(cacheService);
+            Assert.IsNotNull(resultTooLow);
+            Assert.Zero(resultTooLow.Count);
+        }
 
-//            var rawFilepath = Path.Combine(cacheService.BaseFileDirectory, "RandomPropData.raw");
+        [Test]
+        public void RDE_Generates_RandomPropData()
+        {
+            // Arrange
+            RawDataExtractionService rawDataExtractionService =
+                new RawDataExtractionService(null);
 
-//            // Act
-//            var rawData = File.ReadAllText(rawFilepath);
-//            rawDataExtractionService.GenerateRandomPropData(new Dictionary<string, string>()
-//            { 
-//                {"RandomPropData.raw", rawData }
-//            });
+            var incomingRawData = new Dictionary<string, string>()
+            {
+                { "RandomPropPoints.raw", @"{  220,       38,       53, {      146,      110,       82,       73,       73 }, {      147,      110,       82,       73,       74 }, {      148,      110,       82,       73,       75 } }," }
+            };
 
-//            // Assert
-//            //Assert.IsNotNull(data);
-//            //Assert.AreEqual(1300, data.Count);
-//        }
+            // Act
+            var result = rawDataExtractionService.GenerateRandomPropData(incomingRawData);
+            var firstResult = result.FirstOrDefault();
 
-//        [Test]
-//        public void RDE_Generates_SpellData()
-//        {
-//            // Arrange
-//            ICacheService cacheService = new CacheService(null);
-//            IRawDataExtractionService rawDataExtractionService =
-//                new RawDataExtractionService(cacheService);
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Count);
+            Assert.IsNotNull(firstResult);
+            Assert.AreEqual(220, firstResult.ItemLevel);
+            Assert.AreEqual(38, firstResult.DamageReplaceStat);
+            Assert.AreEqual(53, firstResult.DamageSecondary);
+            Assert.AreEqual(5, firstResult.Epic.Length);
+            Assert.AreEqual(146, firstResult.Epic[0]);
+            Assert.AreEqual(73, firstResult.Epic[4]);
+            Assert.AreEqual(5, firstResult.Rare.Length);
+            Assert.AreEqual(147, firstResult.Rare[0]);
+            Assert.AreEqual(74, firstResult.Rare[4]);
+            Assert.AreEqual(5, firstResult.Uncommon.Length);
+            Assert.AreEqual(148, firstResult.Uncommon[0]);
+            Assert.AreEqual(75, firstResult.Uncommon[4]);
+        }
 
-//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "SpellData.json");
+        [Test]
+        public void RDE_Generates_SpellData()
+        {
+            // Arrange
+            RawDataExtractionService rawDataExtractionService =
+                new RawDataExtractionService(null);
 
-//            // Act
-//            rawDataExtractionService.GenerateSpellData();
-//            var rawData = File.ReadAllText(filepath);
+            var incomingRawData = new Dictionary<string, string>()
+            {
+                { "SpellData.raw", @"  { ""The Hunt"" , 345396, 1, 0.000000, 0x0000000000000000, 0x00000800, 0, 0, " +
+                "0, 0, 0, 0.000000, 50.000000,       0, 0, 0, 0, 0,    0, 1, 0, 1500, 0, 0, 0, 0, 0, 0.000000, 0, 0, " +
+                "0, 0, { 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 262144, 0 }, 107, 0x00000000,  0, " + 
+                "  0,  0, 0, 0, 0, 0, 1, 0, 1, 0 }, /* 871236 */" }
+            };
 
-//            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
+            // Act
+            var result = rawDataExtractionService.GenerateSpellData(incomingRawData);
+            var firstResult = result.FirstOrDefault();
 
-//            // Assert
-//            // TODO: Add tests for each field of each spell in a new test class? Against known items with valid values
-//            FileAssert.Exists(filepath);
-//            Assert.IsNotNull(data);
-//            Assert.LessOrEqual(16945, data.Count);
-//        }
+            // Assert
+            // TODO: Add tests for each field of each spell in a new test class? Against known items with valid values
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Count);
+            Assert.IsNotNull(firstResult);
+            Assert.AreEqual("The Hunt", firstResult.Name);
+            Assert.AreEqual(345396, firstResult.Id);
+        }
 
-//        [Test]
-//        public void RDE_Generates_ItemBonuses()
-//        {
-//            // Arrange
-//            ICacheService cacheService = new CacheService(null);
-//            IRawDataExtractionService rawDataExtractionService =
-//                new RawDataExtractionService(cacheService);
+        [Test]
+        public void RDE_Generates_ItemBonuses()
+        {
+            // Arrange
+            RawDataExtractionService rawDataExtractionService =
+                new RawDataExtractionService(null);
 
-//            var filepath = Path.Combine(cacheService.BaseFileDirectory, "ItemBonusData.json");
+            var incomingRawData = new Dictionary<string, string>()
+            {
+                { "ItemBonusData.raw", @"  { 12070, 6432, 13,    1737,       1,     424,   14309,  0 }," }
+            };
 
-//            // Act
-//            rawDataExtractionService.GenerateItemBonusData();
-//            var rawData = File.ReadAllText(filepath);
+            // Act
+            var result = rawDataExtractionService.GenerateItemBonusData(incomingRawData);
+            var firstResult = result.FirstOrDefault();
 
-//            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
-
-//            // Assert
-//            FileAssert.Exists(filepath);
-//            Assert.IsNotNull(data);
-//            Assert.LessOrEqual(9813, data.Count);
-//        }
-//    }
-//}
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Count);
+            Assert.IsNotNull(firstResult);
+            Assert.AreEqual(12070, firstResult.Id);
+            Assert.AreEqual(6432, firstResult.BonusId);
+            Assert.AreEqual(13, (int)firstResult.Type);
+            Assert.AreEqual(1737, firstResult.Value1);
+            Assert.AreEqual(1, firstResult.Value2);
+            Assert.AreEqual(424, firstResult.Value3);
+            Assert.AreEqual(14309, firstResult.Value4);
+            Assert.AreEqual(0, firstResult.Index);
+        }
+    }
+}

--- a/SimcProfileParser.Tests/DataSync/RawDataExtractionServiceTests.cs
+++ b/SimcProfileParser.Tests/DataSync/RawDataExtractionServiceTests.cs
@@ -124,5 +124,27 @@ namespace SimcProfileParser.Tests.DataSync
             Assert.IsNotNull(data);
             Assert.LessOrEqual(16945, data.Count);
         }
+
+        [Test]
+        public void RDE_Generates_ItemBonuses()
+        {
+            // Arrange
+            ICacheService cacheService = new CacheService();
+            IRawDataExtractionService rawDataExtractionService =
+                new RawDataExtractionService(cacheService);
+
+            var filepath = Path.Combine(cacheService.BaseFileDirectory, "ItemBonusData.json");
+
+            // Act
+            rawDataExtractionService.GenerateItemBonusData();
+            var rawData = File.ReadAllText(filepath);
+
+            var data = JsonConvert.DeserializeObject<List<SimcRawItem>>(rawData);
+
+            // Assert
+            FileAssert.Exists(filepath);
+            Assert.IsNotNull(data);
+            Assert.LessOrEqual(9813, data.Count);
+        }
     }
 }

--- a/SimcProfileParser.Tests/RawData/Alfouhk.simc
+++ b/SimcProfileParser.Tests/RawData/Alfouhk.simc
@@ -1,0 +1,251 @@
+﻿# Alfouhk - Holy - 2020-10-06 11:54 - us/Torghast
+# SimC Addon 9.0.1-alpha-10
+# Requires SimulationCraft 901-01 or newer
+
+priest="Alfouhk"
+level=60
+race=dwarf
+region=us
+server=torghast
+role=attack
+
+talents=1111111
+spec=holy
+
+covenant=necrolord
+# conduits_available=
+# renown=40
+
+main_hand=,id=178473,bonus_id=6774/1504/6646
+head=,id=163340,bonus_id=6938,drop_level=50
+neck=,id=177146,bonus_id=6938,drop_level=50
+shoulder=,id=163269,bonus_id=6938,drop_level=50
+back=,id=163311,bonus_id=6938,drop_level=50
+chest=,id=174025,bonus_id=6938,drop_level=50
+wrist=,id=177094,bonus_id=6938,drop_level=50
+hands=,id=163258,bonus_id=6938,drop_level=50
+waist=,id=163343,bonus_id=6938,drop_level=50
+legs=,id=177092,bonus_id=6938,drop_level=50
+#feet=,id=174026,bonus_id=6938,drop_level=50
+finger1=,id=177153,bonus_id=6938/1764,drop_level=50
+finger2=,id=177145,bonus_id=6938,drop_level=50
+trinket1=,id=182453,bonus_id=6652/7215,drop_level=50
+trinket2=,id=177149,bonus_id=6938/607,drop_level=50
+
+### Gear from Bags
+#
+# Empyreal Ordnance (226)
+# trinket1=,id=180117,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Cabalist's Hymnal (226)
+# trinket1=,id=184028,bonus_id=6652/7215/1498/6646,drop_level=50
+#
+# Maldraxxian Warhorn (226)
+# trinket1=,id=180827,bonus_id=6707/7215,drop_level=50
+#
+# Macabre Sheet Music (226)
+# trinket1=,id=184024,bonus_id=6652/7215/1498/6646,drop_level=50
+#
+# Tablet of Despair (226)
+# trinket1=,id=181357,bonus_id=6652/7215,drop_level=50
+#
+# Overflowing Ember Mirror (226)
+# trinket1=,id=181359,bonus_id=7215,drop_level=50
+#
+# Brimming Ember Shard (226)
+# trinket1=,id=181360,bonus_id=6652/7215,drop_level=50
+#
+# Wakener's Frond (226)
+# trinket1=,id=181457,bonus_id=6652/7215,drop_level=50
+#
+# Withergrove Shardling (226)
+# trinket1=,id=181459,bonus_id=6652/7215,drop_level=50
+#
+# Flame of Battle (226)
+# trinket1=,id=181501,bonus_id=6652/7215,drop_level=50
+#
+# Rejuvenating Serum (226)
+# trinket1=,id=181502,bonus_id=6652/7215,drop_level=50
+#
+# Vial of Caustic Liquid (226)
+# trinket1=,id=181503,bonus_id=6652/7215,drop_level=50
+#
+# Glimmerdust's Grand Design (226)
+# trinket1=,id=182451,bonus_id=6652/7215,drop_level=50
+#
+# Everchill Brambles (226)
+# trinket1=,id=182452,bonus_id=6652/7215,drop_level=50
+#
+# Oceanographer's Weather Log (138)
+# trinket1=,id=177151,bonus_id=6938/604,drop_level=50
+#
+# Murmurs in the Dark (226)
+# trinket1=,id=182454,bonus_id=6652/7215,drop_level=50
+#
+# Dreamer's Mending (226)
+# trinket1=,id=182455,bonus_id=6652/7215,drop_level=50
+#
+# Book-Borrower Identification (226)
+# trinket1=,id=182682,bonus_id=6652/7215,drop_level=50
+#
+# Soulsifter Root (226)
+# trinket1=,id=183849,bonus_id=6707/7215,drop_level=50
+#
+# Wakener's Frond (226)
+# trinket1=,id=183850,bonus_id=6707/7215,drop_level=50
+#
+# Withergrove Shardling (226)
+# trinket1=,id=183851,bonus_id=6707/7215,drop_level=50
+#
+# Soul Igniter (226)
+# trinket1=,id=184019,bonus_id=6652/7215/1498/6646,drop_level=50
+#
+# Tuft of Smoldering Plumage (226)
+# trinket1=,id=184020,bonus_id=6652/7215/1498/6646,drop_level=50
+#
+# Glyph of Assimilation (226)
+# trinket1=,id=184021,bonus_id=6652/7215/1498/6646,drop_level=50
+#
+# Consumptive Infusion (226)
+# trinket1=,id=184022,bonus_id=6652/7215/1498/6646,drop_level=50
+#
+# Inscrutable Quantum Device (226)
+# trinket1=,id=179350,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Glowing Endmire Stinger (226)
+# trinket1=,id=179927,bonus_id=6652/7215,drop_level=50
+#
+# Lingering Sunmote (226)
+# trinket1=,id=178850,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Sunblood Amethyst (226)
+# trinket1=,id=178826,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Soulletting Ruby (226)
+# trinket1=,id=178809,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Hopebreaker's Badge (226)
+# trinket1=,id=177813,bonus_id=6907/6652/603/7215,drop_level=50
+#
+# Spiritual Alchemy Stone (226)
+# trinket1=,id=175943,bonus_id=7215,drop_level=50
+#
+# Overflowing Ember Mirror (226)
+# trinket1=,id=177657,bonus_id=6706/7215,drop_level=50
+#
+# Spiritual Alchemy Stone (226)
+# trinket1=,id=175942,bonus_id=7215,drop_level=50
+#
+# Brimming Ember Shard (226)
+# trinket1=,id=175733,bonus_id=6706/7215,drop_level=50
+#
+# Stolen Maw Badge (226)
+# trinket1=,id=175731,bonus_id=6707/7215,drop_level=50
+#
+# Soulsifter Root (226)
+# trinket1=,id=175728,bonus_id=6652/7215,drop_level=50
+#
+# Primalist's Kelpling (226)
+# trinket1=,id=175726,bonus_id=6707/7215,drop_level=50
+#
+# Rejuvenating Serum (226)
+# trinket1=,id=175723,bonus_id=6707/7215,drop_level=50
+#
+# Agitha's Void-Tinged Speartip (226)
+# trinket1=,id=175719,bonus_id=6707/7215,drop_level=50
+#
+# Misfiring Centurion Controller (226)
+# trinket1=,id=173349,bonus_id=6706/7215,drop_level=50
+#
+# Darkmoon Deck: Putrescence (226)
+# trinket1=,id=173069,bonus_id=7215,drop_level=50
+#
+# Essence Extractor (226)
+# trinket1=,id=181334,bonus_id=6652/7215,drop_level=50
+#
+# Boon of the Archon (226)
+# trinket1=,id=180119,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Manabound Mirror (226)
+# trinket1=,id=184029,bonus_id=6652/7215/1498/6646,drop_level=50
+#
+# Dreadfire Vessel (226)
+# trinket1=,id=184030,bonus_id=6652/7215/1498/6646,drop_level=50
+#
+# Siphoning Blood-Drinker (226)
+# trinket1=,id=184279,bonus_id=6652/7215,drop_level=50
+#
+# Spiritual Alchemy Stone (226)
+# trinket1=,id=171323,bonus_id=7215,drop_level=50
+#
+# Darkmoon Deck: Repose (226)
+# trinket1=,id=173078,bonus_id=7215,drop_level=50
+#
+# Infinitely Divisible Ooze (226)
+# trinket1=,id=178769,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Ascended Defender's Crest (226)
+# trinket1=,id=175718,bonus_id=6707/7215,drop_level=50
+#
+# Overflowing Anima Prison (226)
+# trinket1=,id=178849,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Vial of Caustic Liquid (226)
+# trinket1=,id=175722,bonus_id=6707/7215,drop_level=50
+#
+# Siphoning Phylactery Shard (226)
+# trinket1=,id=178783,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Newcomer's Gladiatorial Badge (226)
+# trinket1=,id=175725,bonus_id=6707/7215,drop_level=50
+#
+# Unbound Changeling (226)
+# trinket1=,id=178708,bonus_id=6652/6917/7215/1547/6646,drop_level=50
+#
+# Elder's Stormseed (226)
+# trinket1=,id=175727,bonus_id=6707/7215,drop_level=50
+#
+# Satchel of Misbegotten Minions (226)
+# trinket1=,id=178772,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# Rotbriar Sprout (226)
+# trinket1=,id=175729,bonus_id=6652/7215,drop_level=50
+#
+# Spiritual Alchemy Stone (226)
+# trinket1=,id=175941,bonus_id=7215,drop_level=50
+#
+# Tablet of Despair (226)
+# trinket1=,id=175732,bonus_id=6707/7215,drop_level=50
+#
+# Vial of Vampiric Essence (226)
+# trinket1=,id=178810,bonus_id=6652/7215/1547/6646,drop_level=50
+#
+# 7th Legionnaire's Spellhammer (138)
+# main_hand=,id=177141,bonus_id=6938,drop_level=50
+#
+# Sinful Aspirant's Staff (184)
+# main_hand=,id=178473,bonus_id=6775/1498/6646
+#
+# Sinful Aspirant's Staff (171)
+# main_hand=,id=178473,bonus_id=6777/1485/6616
+#
+# 7th Legionnaire's Wand (138)
+# main_hand=,id=177135,bonus_id=6938,drop_level=50
+#
+# Battle Tested Staff (151)
+# main_hand=,id=183090
+#
+# Sinful Aspirant's Staff (158)
+# main_hand=,id=178473,bonus_id=6801/1472/6616
+#
+# Sinful Aspirant's Staff (164)
+# main_hand=,id=178473,bonus_id=6778/1478/6616
+#
+# 7th Legionnaire's Stave (138)
+# main_hand=,id=177133,bonus_id=6938,drop_level=50
+#
+# Sinful Aspirant's Staff (177)
+# main_hand=,id=178473,bonus_id=6776/1491/6616
+#
+# 7th Legionnaire's Censer (138)
+# off_hand=,id=177139,bonus_id=6938,drop_level=50

--- a/SimcProfileParser.Tests/SimcItemCreationServiceTests.cs
+++ b/SimcProfileParser.Tests/SimcItemCreationServiceTests.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Serilog;
+using SimcProfileParser.DataSync;
+using SimcProfileParser.Interfaces.DataSync;
+using SimcProfileParser.Model.Profile;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimcProfileParser.Tests
+{
+    [TestFixture]
+    public class SimcItemCreationServiceTests
+    {
+        private ILoggerFactory _loggerFactory;
+
+        SimcParsedProfile ParsedProfile { get; set; }
+
+        [OneTimeSetUp]
+        public async Task InitOnce()
+        {
+            // Configure Logging
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.FromLogContext()
+                .WriteTo.File("logs" + Path.DirectorySeparatorChar + "SimcProfileParser.log", rollingInterval: RollingInterval.Day)
+                .CreateLogger();
+
+            _loggerFactory = LoggerFactory.Create(builder => builder
+                .AddSerilog()
+                .AddFilter(level => level >= LogLevel.Trace));
+
+            // Load a data file
+            var testFile = @"RawData" + Path.DirectorySeparatorChar + "Alfouhk.simc";
+            var testFileContents = await File.ReadAllLinesAsync(testFile);
+            var testFileString = new List<string>(testFileContents);
+
+            // Create a new profile service
+            var simcParser = new SimcParserService(_loggerFactory.CreateLogger<SimcParserService>());
+            ParsedProfile = simcParser.ParseProfileAsync(testFileString);
+
+            ICacheService cacheService = new CacheService();
+            IRawDataExtractionService rawDataExtractionService =
+                new RawDataExtractionService(cacheService);
+
+            rawDataExtractionService.GenerateCombatRatingMultipliers();
+            rawDataExtractionService.GenerateStaminaMultipliers();
+            rawDataExtractionService.GenerateItemData();
+            rawDataExtractionService.GenerateRandomPropData();
+            rawDataExtractionService.GenerateSpellData();
+        }
+        [Test]
+        public void ICS_Test()
+        {
+            // Arrange
+            ICacheService cacheService = new CacheService();
+            var ics = new SimcItemCreationService(cacheService,
+                _loggerFactory.CreateLogger<SimcItemCreationService>());
+
+            // Act
+            var result = ics.CreateItemsFromProfile(ParsedProfile);
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+    }
+}

--- a/SimcProfileParser.Tests/SimcItemCreationServiceTests.cs
+++ b/SimcProfileParser.Tests/SimcItemCreationServiceTests.cs
@@ -42,21 +42,16 @@ namespace SimcProfileParser.Tests
             var simcParser = new SimcParserService(_loggerFactory.CreateLogger<SimcParserService>());
             ParsedProfile = simcParser.ParseProfileAsync(testFileString);
 
-            ICacheService cacheService = new CacheService();
-            IRawDataExtractionService rawDataExtractionService =
-                new RawDataExtractionService(cacheService);
-
-            rawDataExtractionService.GenerateCombatRatingMultipliers();
-            rawDataExtractionService.GenerateStaminaMultipliers();
-            rawDataExtractionService.GenerateItemData();
-            rawDataExtractionService.GenerateRandomPropData();
-            rawDataExtractionService.GenerateSpellData();
+            
         }
         [Test]
         public void ICS_Test()
         {
             // Arrange
-            ICacheService cacheService = new CacheService();
+            IRawDataExtractionService rawDataExtractionService =
+                new RawDataExtractionService(_loggerFactory.CreateLogger<RawDataExtractionService>());
+            ICacheService cacheService = new CacheService(rawDataExtractionService, _loggerFactory.CreateLogger<CacheService>());
+
             var ics = new SimcItemCreationService(cacheService,
                 _loggerFactory.CreateLogger<SimcItemCreationService>());
 

--- a/SimcProfileParser.Tests/SimcProfileParser.Tests.csproj
+++ b/SimcProfileParser.Tests/SimcProfileParser.Tests.csproj
@@ -32,7 +32,28 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="RawData\Aleanar.simc">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="RawData\Alfouhk.simc">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="RawData\Ardaysauk.simc">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="RawData\Camiloplyi.simc">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="RawData\Gnumrekt.simc">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="RawData\Hierophant.simc">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="RawData\Hierophantx.simc">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="RawData\Marklunk.simc">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/SimcProfileParser/DataSync/CacheService.cs
+++ b/SimcProfileParser/DataSync/CacheService.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.VisualBasic.FileIO;
+using Newtonsoft.Json;
 using SimcProfileParser.Interfaces.DataSync;
 using SimcProfileParser.Model.DataSync;
 using System;
@@ -17,71 +19,210 @@ namespace SimcProfileParser.DataSync
     internal class CacheService : ICacheService
     {
         public string BaseFileDirectory { get; }
+
         protected IList<CacheFileConfiguration> _registeredFiles;
+        protected IDictionary<SimcParsedFileType, object> _cachedFileData;
+        protected readonly IRawDataExtractionService _rawDataExtractionService;
+        protected readonly ILogger _logger;
 
         public IReadOnlyCollection<CacheFileConfiguration> RegisteredFiles => new ReadOnlyCollection<CacheFileConfiguration>(_registeredFiles);
 
-        public CacheService()
+        public CacheService(IRawDataExtractionService rawDataExtractionService,
+            ILogger logger)
         {
             _registeredFiles = new List<CacheFileConfiguration>();
+            _cachedFileData = new Dictionary<SimcParsedFileType, object>();
 
             BaseFileDirectory = Path.Combine(
                 AppDomain.CurrentDomain.BaseDirectory, "SimcProfileParserData");
 
-            ETagCacheData = GetCacheData();
-        }
+            _eTagCacheData = GetCacheData();
+            _rawDataExtractionService = rawDataExtractionService;
+            _logger = logger;
 
-        public CacheService(IList<CacheFileConfiguration> registeredFiles)
-            : this()
-        {
-            _registeredFiles = registeredFiles;
-        }
-
-        string ICacheService.GetFileContents(SimcFileType FileType)
-        {
-            var fileConfig = _registeredFiles.Where(f => f.FileType == FileType).FirstOrDefault();
-
-            if (fileConfig != null)
+            ((ICacheService)this).RegisterFileConfiguration(new CacheFileConfiguration()
             {
-                var eTag = ETagCacheData
-                    .Where(e => e.Filename == fileConfig.LocalFile.LocalPath)
-                    .FirstOrDefault();
+                LocalParsedFile = "ItemDataNew.json",
+                ParsedFileType = SimcParsedFileType.ItemDataNew,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ItemData.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/item_data.inc" },
+                    { "ItemEffect.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/item_effect.inc" }
+                }
+            });
 
-                // If there is no cache data, or the file doesn't exist then re-fetch it
-                if (eTag == null || !File.Exists(fileConfig.LocalFile.LocalPath))
-                    eTag = null;
+            ((ICacheService)this).RegisterFileConfiguration(new CacheFileConfiguration()
+            {
+                LocalParsedFile = "ItemDataOld.json",
+                ParsedFileType = SimcParsedFileType.ItemDataOld,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ItemData.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/item_data.inc" },
+                    { "ItemEffect.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/item_effect.inc" }
+                }
+            });
 
-                ((ICacheService)this).DownloadFileIfChanged(
-                    fileConfig.RemoteFile, fileConfig.LocalFile, eTag?.ETag);
+            ((ICacheService)this).RegisterFileConfiguration(new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/sc_scale_data.inc" }
+                }
+            });
 
-                var data = File.ReadAllText(fileConfig.LocalFile.LocalPath);
+            ((ICacheService)this).RegisterFileConfiguration(new CacheFileConfiguration()
+            {
+                LocalParsedFile = "StaminaMultipliers.json",
+                ParsedFileType = SimcParsedFileType.StaminaMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/sc_scale_data.inc" }
+                }
+            });
 
-                return data;
-            }
-            else
-                return "";
+            ((ICacheService)this).RegisterFileConfiguration(new CacheFileConfiguration()
+            {
+                LocalParsedFile = "RandomPropPoints.json",
+                ParsedFileType = SimcParsedFileType.RandomPropPoints,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "RandomPropPoints.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/rand_prop_points.inc" }
+                }
+            });
+
+            ((ICacheService)this).RegisterFileConfiguration(new CacheFileConfiguration()
+            {
+                LocalParsedFile = "SpellData.json",
+                ParsedFileType = SimcParsedFileType.SpellData,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "SpellData.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/sc_spell_data.inc" }
+                }
+            });
+
+            ((ICacheService)this).RegisterFileConfiguration(new CacheFileConfiguration()
+            {
+                LocalParsedFile = "ItemBonusData.json",
+                ParsedFileType = SimcParsedFileType.ItemBonusData,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ItemBonusData.raw", "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/item_bonus.inc" }
+                }
+            });
         }
 
-        bool ICacheService.DownloadFile(Uri sourceUri, Uri destinationUri)
+        /// <summary>
+        /// Get the parsed .json file contents deserialised into T, based on the provided file type.
+        /// </summary>
+        /// <typeparam name="T">Type to deserialise the json into</typeparam>
+        /// <param name="fileType">Type of file to return data from</param>
+        T ICacheService.GetParsedFileContents<T>(SimcParsedFileType fileType)
         {
-            WebClient client = new WebClient();
-
-            try
+            // First check if we already have the data loaded:
+            if(_cachedFileData.ContainsKey(fileType))
             {
-                var baseDirectory = new Uri(destinationUri, ".");
-                if (!Directory.Exists(baseDirectory.OriginalString))
-                    Directory.CreateDirectory(baseDirectory.OriginalString);
+                var cachedData = _cachedFileData[fileType];
 
-                client.DownloadFile(sourceUri, destinationUri.LocalPath);
+                if (cachedData is T t)
+                {
+                    return t;
+                }
+
+                try
+                {
+                    return (T)Convert.ChangeType(cachedData, typeof(T));
+                }
+                catch (InvalidCastException)
+                {
+                    return default;
+                }
             }
-            catch (Exception)
+
+            var configuration = _registeredFiles.Where(f => f.ParsedFileType == fileType).FirstOrDefault();
+            var localPath = new Uri(Path.Combine(BaseFileDirectory, configuration.LocalParsedFile)).LocalPath;
+
+            if (configuration == null)
+                throw new ArgumentOutOfRangeException("Supplied fileType has not been registered.");
+            
+            // If the file doesn't exist, generate it.
+            if (!File.Exists(localPath))
             {
-                return false;
+                ((ICacheService)this).GenerateParsedFile(fileType);
             }
-            return true;
+
+            var fileText = File.ReadAllText(localPath);
+
+            var deserialisedData = JsonConvert.DeserializeObject<T>(fileText);
+
+            _cachedFileData.Add(fileType, deserialisedData);
+
+            return deserialisedData;
         }
 
-        bool ICacheService.DownloadFileIfChanged(Uri sourceUri, Uri destinationUri, string eTag)
+        /// <summary>
+        /// Generates a parsed .json file for the specified configuration by calling the RawDataExtractionService
+        /// </summary>
+        /// <param name="fileType">Type of file to generate data for</param>
+        void ICacheService.GenerateParsedFile(SimcParsedFileType fileType)
+        {
+            var configuration = _registeredFiles.Where(f => f.ParsedFileType == fileType).FirstOrDefault();
+
+            if (configuration == null)
+                throw new ArgumentOutOfRangeException("Supplied fileType has not been registered.");
+
+            // Gather together all the raw data the extraction service needs to run its process
+            var rawData = new Dictionary<string, string>();
+            foreach (var rawFile in configuration.RawFiles)
+            {
+                var data = GetRawFileContents(configuration, rawFile.Key);
+                rawData.Add(rawFile.Key, data);
+            }
+
+            // Generate the parsed .json file
+            var parsedData = _rawDataExtractionService.GenerateData(configuration.ParsedFileType, rawData);
+            var localPath = Path.Combine(BaseFileDirectory, configuration.LocalParsedFile);
+
+            File.WriteAllText(localPath, JsonConvert.SerializeObject(parsedData));
+        }
+
+        void ICacheService.RegisterFileConfiguration(CacheFileConfiguration configuration)
+        {
+            var exists = _registeredFiles
+                .Where(f => f.ParsedFileType == configuration.ParsedFileType)
+                .FirstOrDefault();
+
+            if (exists != null)
+            {
+                _registeredFiles.Remove(exists);
+            }
+
+            _registeredFiles.Add(configuration);
+        }
+
+        internal string GetRawFileContents(CacheFileConfiguration configuration, string localRawFile)
+        {
+            var localPath = new Uri(Path.Combine(BaseFileDirectory, localRawFile)).LocalPath;
+            if (!File.Exists(localPath))
+            {
+                var destinationRawFile = configuration.RawFiles.Where(r => r.Key == localRawFile).FirstOrDefault();
+                DownloadFileIfChanged(new Uri(destinationRawFile.Value),
+                    new Uri(Path.Combine(BaseFileDirectory, destinationRawFile.Key)));
+            }
+
+            var data = File.ReadAllText(localPath);
+
+            return data;
+        }
+
+        /// <summary>
+        /// Check if the local file exists and the cache matches
+        /// </summary>
+        /// <param name="sourceUri"></param>
+        /// <param name="destinationUri"></param>
+        /// <returns></returns>
+        internal bool DownloadFileIfChanged(Uri sourceUri, Uri destinationUri)
         {
             HttpClient httpClient = new HttpClient();
 
@@ -100,68 +241,93 @@ namespace SimcProfileParser.DataSync
                 return false;
             }
 
-            if (eTag != null && response.Headers.ETag.Tag == eTag)
-                return true;
+            // Grab the cache info and the files last modified date.
+            var eTag = _eTagCacheData
+                .Where(e => e.Filename == destinationUri.LocalPath)
+                .FirstOrDefault();
 
-            var downloadResponse = ((ICacheService)this).DownloadFile(sourceUri, destinationUri);
+            DateTime lastModified = DateTime.UtcNow;
+
+            if(File.Exists(destinationUri.LocalPath))
+                lastModified = File.GetLastWriteTimeUtc(destinationUri.LocalPath);
+
+            // Check if we need to download it or not.
+            if (eTag != null && // If there is an etag
+                response.Headers.ETag.Tag == eTag.ETag && // and they match
+                eTag.LastModified == lastModified) // and the last modified's match
+                return true; // Then we don't need to download it.
+
+            var downloadResponse = DownloadFile(sourceUri, destinationUri);
 
             // If the download was successful, save the etag.
             if(downloadResponse)
             {
-                UpdateCacheData(destinationUri.LocalPath, response.Headers.ETag.Tag);
+                lastModified = File.GetLastWriteTimeUtc(destinationUri.LocalPath);
+                UpdateCacheData(destinationUri.LocalPath, response.Headers.ETag.Tag, lastModified);
             }
 
             return downloadResponse;
         }
 
-        void ICacheService.RegisterFileConfiguration(SimcFileType fileType, string localFilename, string remoteFilename)
+        internal bool DownloadFile(Uri sourceUri, Uri destinationUri)
         {
-            var exists = _registeredFiles.Where(f => f.FileType == fileType).FirstOrDefault();
+            WebClient client = new WebClient();
 
-            if(exists != null)
+            try
             {
-                _registeredFiles.Remove(exists);
+                var baseDirectory = new Uri(destinationUri, ".");
+                if (!Directory.Exists(baseDirectory.OriginalString))
+                    Directory.CreateDirectory(baseDirectory.OriginalString);
+
+                client.DownloadFile(sourceUri, destinationUri.LocalPath);
             }
-
-            var configuration = new CacheFileConfiguration()
+            catch (Exception)
             {
-                FileType = fileType,
-                RemoteFile = new Uri(remoteFilename),
-                LocalFile = new Uri(Path.Combine(BaseFileDirectory, localFilename))
-            };
+                return false;
+            }
+            return true;
+        }
 
-            _registeredFiles.Add(configuration);
+        internal void SaveParsedFile(SimcParsedFileType fileType, object contents)
+        {
+            var fileConfig = _registeredFiles.Where(f => f.ParsedFileType == fileType).FirstOrDefault();
+            var localPath = new Uri(Path.Combine(BaseFileDirectory, fileConfig.LocalParsedFile)).LocalPath;
+
+            var data = JsonConvert.SerializeObject(contents);
+
+            File.WriteAllText(localPath, data);
         }
 
         #region eTag Cache
 
         private readonly string _etagCacheDataFile = "FileDownloadCache.json";
-        internal List<FileETag> ETagCacheData = new List<FileETag>();
+        protected List<FileETag> _eTagCacheData = new List<FileETag>();
 
         /// <summary>
         /// Update the cache with an entry
         /// </summary>
         /// <param name="filename"></param>
         /// <param name="eTag"></param>
-        internal void UpdateCacheData(string filename, string eTag)
+        internal void UpdateCacheData(string filename, string eTag, DateTime lastModified)
         {
-            if (ETagCacheData.Count == 0)
-                ETagCacheData = GetCacheData();
+            if (_eTagCacheData.Count == 0)
+                _eTagCacheData = GetCacheData();
 
-            var existing = ETagCacheData.Where(e => e.Filename == filename).FirstOrDefault();
+            var existing = _eTagCacheData.Where(e => e.Filename == filename).FirstOrDefault();
 
             if (existing != null)
                 existing.ETag = eTag;
             else
             {
-                ETagCacheData.Add(new FileETag()
+                _eTagCacheData.Add(new FileETag()
                 {
                     Filename = filename,
-                    ETag = eTag
+                    ETag = eTag,
+                    LastModified = lastModified
                 });
             }
 
-            SaveCacheData(ETagCacheData);
+            SaveCacheData(_eTagCacheData);
         }
 
         /// <summary>

--- a/SimcProfileParser/DataSync/RawDataExtractionService.cs
+++ b/SimcProfileParser/DataSync/RawDataExtractionService.cs
@@ -219,7 +219,7 @@ namespace SimcProfileParser.DataSync
                     item.RequiredSkillLevel = Convert.ToInt32(data[8]);
 
                     // 9 is quality
-                    item.Quality = Convert.ToInt32(data[9]);
+                    item.Quality = (ItemQuality)Convert.ToInt32(data[9]);
 
                     // 10 is inventory type
                     // TODO: parse this to the enum value ?
@@ -597,7 +597,7 @@ namespace SimcProfileParser.DataSync
                 itemBonus.BonusId = Convert.ToUInt32(data[1]);
 
                 // 2 is type
-                itemBonus.Type = Convert.ToUInt32(data[2]);
+                itemBonus.Type = (ItemBonusType)Convert.ToUInt32(data[2]);
 
                 // 3 is value 1
                 itemBonus.Value1 = Convert.ToInt32(data[3]);

--- a/SimcProfileParser/DataSync/RawDataExtractionService.cs
+++ b/SimcProfileParser/DataSync/RawDataExtractionService.cs
@@ -64,9 +64,9 @@ namespace SimcProfileParser.DataSync
 
             float[][] values = new float[4][];
             values[0] = ParseRatingGroup(groups[1]);
-            values[1] = ParseRatingGroup(groups[1]);
-            values[2] = ParseRatingGroup(groups[1]);
-            values[3] = ParseRatingGroup(groups[1]);
+            values[1] = ParseRatingGroup(groups[2]);
+            values[2] = ParseRatingGroup(groups[3]);
+            values[3] = ParseRatingGroup(groups[4]);
 
             var generatedData = JsonConvert.SerializeObject(values);
 
@@ -87,9 +87,9 @@ namespace SimcProfileParser.DataSync
 
             float[][] values = new float[4][];
             values[0] = ParseRatingGroup(groups[1]);
-            values[1] = ParseRatingGroup(groups[1]);
-            values[2] = ParseRatingGroup(groups[1]);
-            values[3] = ParseRatingGroup(groups[1]);
+            values[1] = ParseRatingGroup(groups[2]);
+            values[2] = ParseRatingGroup(groups[3]);
+            values[3] = ParseRatingGroup(groups[4]);
 
             var generatedData = JsonConvert.SerializeObject(values);
 

--- a/SimcProfileParser/DataSync/RawDataExtractionService.cs
+++ b/SimcProfileParser/DataSync/RawDataExtractionService.cs
@@ -18,6 +18,7 @@ namespace SimcProfileParser.DataSync
         void GenerateItemData();
         void GenerateRandomPropData();
         void GenerateSpellData();
+        void GenerateItemBonusData();
     }
 
     /// <summary>
@@ -50,6 +51,11 @@ namespace SimcProfileParser.DataSync
                Model.DataSync.SimcFileType.ScSpellDataInc,
                "SpellData.raw",
                "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/sc_spell_data.inc");
+
+            _cacheService.RegisterFileConfiguration(
+               Model.DataSync.SimcFileType.ItemBonusInc,
+               "ItemBonusData.raw",
+               "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/item_bonus.inc");
         }
 
         void IRawDataExtractionService.GenerateCombatRatingMultipliers()
@@ -540,6 +546,68 @@ namespace SimcProfileParser.DataSync
 
             File.WriteAllText(
                 Path.Combine(_cacheService.BaseFileDirectory, "SpellData.json"),
+                generatedData);
+        }
+
+        void IRawDataExtractionService.GenerateItemBonusData()
+        {
+            var rawData = _cacheService.GetFileContents(Model.DataSync.SimcFileType.ItemBonusInc);
+
+            var lines = rawData.Split(
+                new[] { "\r\n", "\r", "\n" },
+                StringSplitOptions.None
+            );
+
+            var itemBonuses = new List<SimcRawItemBonus>();
+
+            foreach(var line in lines)
+            {
+                // Split the data up
+                var data = line.Split(',');
+
+                // Only process valid lines
+                if (data.Count() < 9)
+                    continue;
+
+                var itemBonus = new SimcRawItemBonus();
+
+                // Clean the data up
+                for (var i = 0; i < data.Length; i++)
+                {
+                    data[i] = data[i].Replace("}", "").Replace("{", "").Trim();
+                }
+
+                // 0 is Id
+                itemBonus.Id = Convert.ToUInt32(data[0]);
+
+                // 1 is bonus id
+                itemBonus.BonusId = Convert.ToUInt32(data[1]);
+
+                // 2 is type
+                itemBonus.Type = Convert.ToUInt32(data[2]);
+
+                // 3 is value 1
+                itemBonus.Value1 = Convert.ToInt32(data[3]);
+
+                // 4 is value 2
+                itemBonus.Value2 = Convert.ToInt32(data[4]);
+
+                // 5 is value 3
+                itemBonus.Value3 = Convert.ToInt32(data[5]);
+
+                // 6 is value 4
+                itemBonus.Value4 = Convert.ToInt32(data[6]);
+
+                // 7 is index
+                itemBonus.Index = Convert.ToUInt32(data[7]);
+
+                itemBonuses.Add(itemBonus);
+            }
+
+            var generatedData = JsonConvert.SerializeObject(itemBonuses);
+
+            File.WriteAllText(
+                Path.Combine(_cacheService.BaseFileDirectory, "ItemBonusData.json"),
                 generatedData);
         }
     }

--- a/SimcProfileParser/DataSync/RawDataExtractionService.cs
+++ b/SimcProfileParser/DataSync/RawDataExtractionService.cs
@@ -223,10 +223,10 @@ namespace SimcProfileParser.DataSync
 
                     // 10 is inventory type
                     // TODO: parse this to the enum value ?
-                    item.InventoryType = Convert.ToInt32(data[10]);
+                    item.InventoryType = (InventoryType)Convert.ToInt32(data[10]);
 
                     // 11 is item class
-                    item.ItemClass = Convert.ToInt32(data[11]);
+                    item.ItemClass = (ItemClass)Convert.ToInt32(data[11]);
 
                     // 12 is item subclass
                     item.ItemSubClass = Convert.ToInt32(data[12]);

--- a/SimcProfileParser/Interfaces/DataSync/ICacheService.cs
+++ b/SimcProfileParser/Interfaces/DataSync/ICacheService.cs
@@ -1,17 +1,42 @@
 ﻿using SimcProfileParser.Model.DataSync;
+using SimcProfileParser.Model.RawData;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace SimcProfileParser.Interfaces.DataSync
 {
+    /// <summary>
+    /// A service for keeping local parsed json files ready for use.
+    /// </summary>
     public interface ICacheService
     {
+        /// <summary>
+        /// The base directory the cache service stores its files
+        /// </summary>
         string BaseFileDirectory { get; }
+        /// <summary>
+        /// Collection of already registered file configurations
+        /// </summary>
         IReadOnlyCollection<CacheFileConfiguration> RegisteredFiles { get; }
-        string GetFileContents(SimcFileType FileType);
-        bool DownloadFileIfChanged(Uri sourceUri, Uri destinationUri, string eTag);
-        bool DownloadFile(Uri sourceUri, Uri destinationUri);
-        void RegisterFileConfiguration(SimcFileType fileType, string localFilename, string remoteFilename);
+        /// <summary>
+        /// Register a configuration representing a parsed json file and its raw sources
+        /// </summary>
+        /// <param name="configuration"></param>
+        void RegisterFileConfiguration(CacheFileConfiguration configuration);
+
+        /// <summary>
+        /// Get back the parsed file contents from disk
+        /// </summary>
+        /// <typeparam name="T">Return type to attempt to deserialise into</typeparam>
+        /// <param name="fileType">Type of parsed file to return</param>
+        /// <returns></returns>
+        T GetParsedFileContents<T>(SimcParsedFileType fileType);
+        /// <summary>
+        /// Generates a version of the raw files that's stored as parsed.json data which can be
+        /// used by GetParsedFileContents to extract the parsed data as objects
+        /// </summary>
+        /// <param name="fileType">The type of file this should generate</param>
+        void GenerateParsedFile(SimcParsedFileType fileType);
     }
 }

--- a/SimcProfileParser/Interfaces/DataSync/ICacheService.cs
+++ b/SimcProfileParser/Interfaces/DataSync/ICacheService.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace SimcProfileParser.Interfaces.DataSync
 {
-    internal interface ICacheService
+    public interface ICacheService
     {
         string BaseFileDirectory { get; }
         IReadOnlyCollection<CacheFileConfiguration> RegisteredFiles { get; }

--- a/SimcProfileParser/Model/DataSync/CacheFileConfiguration.cs
+++ b/SimcProfileParser/Model/DataSync/CacheFileConfiguration.cs
@@ -6,8 +6,11 @@ namespace SimcProfileParser.Model.DataSync
 {
     public class CacheFileConfiguration
     {
-        internal SimcFileType FileType { get; set; }
-        internal Uri LocalFile { get; set; }
-        internal Uri RemoteFile { get; set; }
+        internal SimcParsedFileType ParsedFileType { get; set; }
+        /// <summary>
+        /// Dictionary in the form of Local file : Remote file
+        /// </summary>
+        internal Dictionary<string, string> RawFiles { get; set; }
+        internal string LocalParsedFile { get; set; }
     }
 }

--- a/SimcProfileParser/Model/DataSync/FileETag.cs
+++ b/SimcProfileParser/Model/DataSync/FileETag.cs
@@ -8,5 +8,6 @@ namespace SimcProfileParser.Model.DataSync
     {
         public string Filename { get; set; }
         public string ETag { get; set; }
+        public DateTime LastModified { get; set; }
     }
 }

--- a/SimcProfileParser/Model/DataSync/SimcFileTypeEnum.cs
+++ b/SimcProfileParser/Model/DataSync/SimcFileTypeEnum.cs
@@ -11,6 +11,7 @@ namespace SimcProfileParser.Model.DataSync
         RandomPropPointsInc,
         ScaleDataInc,
         ScEnumsHpp,
-        DataEnumsHh
+        DataEnumsHh,
+        ItemBonusInc
     }
 }

--- a/SimcProfileParser/Model/DataSync/SimcFileTypeEnum.cs
+++ b/SimcProfileParser/Model/DataSync/SimcFileTypeEnum.cs
@@ -4,15 +4,14 @@ using System.Text;
 
 namespace SimcProfileParser.Model.DataSync
 {
-    public enum SimcFileType
+    public enum SimcParsedFileType
     {
-        ScSpellDataInc,
-        ItemDataInc,
-        RandomPropPointsInc,
-        ScaleDataInc,
-        ScEnumsHpp,
-        DataEnumsHh,
-        ItemBonusInc,
-        ItemEffectInc
+        ItemDataNew,
+        ItemDataOld,
+        CombatRatingMultipliers,
+        StaminaMultipliers,
+        SpellData,
+        RandomPropPoints,
+        ItemBonusData
     }
 }

--- a/SimcProfileParser/Model/DataSync/SimcFileTypeEnum.cs
+++ b/SimcProfileParser/Model/DataSync/SimcFileTypeEnum.cs
@@ -12,6 +12,7 @@ namespace SimcProfileParser.Model.DataSync
         ScaleDataInc,
         ScEnumsHpp,
         DataEnumsHh,
-        ItemBonusInc
+        ItemBonusInc,
+        ItemEffectInc
     }
 }

--- a/SimcProfileParser/Model/Profile/SimcParsedItem.cs
+++ b/SimcProfileParser/Model/Profile/SimcParsedItem.cs
@@ -8,7 +8,7 @@ namespace SimcProfileParser.Model.Profile
     public class SimcParsedItem
     {
         public string Slot { get; internal set; }
-        public int ItemId { get; internal set; }
+        public uint ItemId { get; internal set; }
         public int EnchantId { get; internal set; }
         public IReadOnlyCollection<int> GemIds { get; internal set; }
         public IReadOnlyCollection<int> BonusIds { get; internal set; }

--- a/SimcProfileParser/Model/RawData/SimcRawDataEnums.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawDataEnums.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace SimcProfileParser.Model.RawData
 {
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/sc_enums.hpp#L926
+    // from sc_enums
     /// <summary>
     /// (stat_e) A list of all stats and their internal Simc reference numbers
     /// </summary>
@@ -60,7 +60,7 @@ namespace SimcProfileParser.Model.RawData
         STAT_MAX
     };
 
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L456
+    // from data_enums.hh
     public enum ItemModType
     {
         ITEM_MOD_NONE = -1,
@@ -131,8 +131,8 @@ namespace SimcProfileParser.Model.RawData
         ITEM_MOD_STRENGTH_INTELLECT = 74,
     };
 
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L261
-    enum ItemClass
+    // from data_enums.hh
+    public enum ItemClass
     {
         ITEM_CLASS_CONSUMABLE = 0,
         ITEM_CLASS_CONTAINER = 1,
@@ -153,7 +153,7 @@ namespace SimcProfileParser.Model.RawData
         ITEM_CLASS_GLYPH = 16
     };
 
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L282
+    // from data_enums.hh
     enum ItemSubclassWeapon
     {
         ITEM_SUBCLASS_WEAPON_AXE = 0,
@@ -180,7 +180,7 @@ namespace SimcProfileParser.Model.RawData
         ITEM_SUBCLASS_WEAPON_INVALID = 31
     };
 
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L308
+    // from data_enums.hh
     enum ItemSubclassArmor
     {
         ITEM_SUBCLASS_ARMOR_MISC = 0,
@@ -197,7 +197,7 @@ namespace SimcProfileParser.Model.RawData
         ITEM_SUBCLASS_ARMOR_RELIC = 11
     };
 
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L324
+    // from data_enums.hh
     enum ItemSubclassConsumable
     {
         ITEM_SUBCLASS_CONSUMABLE = 0,
@@ -211,7 +211,7 @@ namespace SimcProfileParser.Model.RawData
         ITEM_SUBCLASS_CONSUMABLE_OTHER = 8
     };
 
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L337
+    // from data_enums.hh
     public enum InventoryType
     {
         INVTYPE_NON_EQUIP = 0,
@@ -246,7 +246,7 @@ namespace SimcProfileParser.Model.RawData
         INVTYPE_MAX = 29
     };
 
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L371
+    // from data_enums.hh
     public enum ItemQuality
     {
         ITEM_QUALITY_NONE = -1,
@@ -260,7 +260,7 @@ namespace SimcProfileParser.Model.RawData
         ITEM_QUALITY_MAX = 7
     };
 
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh
+    // from data_enums.hh
     enum ItemBonusType
     {
         ITEM_BONUS_ILEVEL = 1,
@@ -278,7 +278,7 @@ namespace SimcProfileParser.Model.RawData
         ITEM_BONUS_MOD_ITEM_STAT = 25, // Modify item stat to type
     };
 
-    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh
+    // from data_enums.hh
     public enum ItemSocketColor
     {
         SOCKET_COLOR_NONE = 0,
@@ -312,5 +312,16 @@ namespace SimcProfileParser.Model.RawData
                                             SOCKET_COLOR_FEL | SOCKET_COLOR_ARCANE | SOCKET_COLOR_FROST |
                                             SOCKET_COLOR_FIRE | SOCKET_COLOR_WATER | SOCKET_COLOR_LIFE |
                                             SOCKET_COLOR_WIND | SOCKET_COLOR_HOLY
+    };
+
+    // from data_enums.hh
+    enum CombatRatingMultiplayerType
+    {
+        CR_MULTIPLIER_INVALID = -1,
+        CR_MULTIPLIER_ARMOR,
+        CR_MULTIPLIER_WEAPON,
+        CR_MULTIPLIER_TRINKET,
+        CR_MULTIPLIER_JEWLERY,
+        CR_MULTIPLIER_MAX
     };
 }

--- a/SimcProfileParser/Model/RawData/SimcRawDataEnums.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawDataEnums.cs
@@ -247,7 +247,7 @@ namespace SimcProfileParser.Model.RawData
     };
 
     // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L371
-    enum ItemQuality
+    public enum ItemQuality
     {
         ITEM_QUALITY_NONE = -1,
         ITEM_QUALITY_POOR = 0,
@@ -258,5 +258,59 @@ namespace SimcProfileParser.Model.RawData
         ITEM_QUALITY_LEGENDARY = 5,
         ITEM_QUALITY_ARTIFACT = 6,
         ITEM_QUALITY_MAX = 7
+    };
+
+    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh
+    enum ItemBonusType
+    {
+        ITEM_BONUS_ILEVEL = 1,
+        ITEM_BONUS_MOD = 2,
+        ITEM_BONUS_QUALITY = 3,
+        ITEM_BONUS_DESC = 4,
+        ITEM_BONUS_SUFFIX = 5,
+        ITEM_BONUS_SOCKET = 6,
+        ITEM_BONUS_REQ_LEVEL = 8,
+        ITEM_BONUS_SCALING = 11, // Scaling based on ScalingStatDistribution.db2
+        ITEM_BONUS_SCALING_2 = 13, // Scaling based on ScalingStatDistribution.db2
+        ITEM_BONUS_SET_ILEVEL = 14,
+        ITEM_BONUS_ADD_RANK = 17, // Add artifact power rank to a specific trait
+        ITEM_BONUS_ADD_ITEM_EFFECT = 23,
+        ITEM_BONUS_MOD_ITEM_STAT = 25, // Modify item stat to type
+    };
+
+    // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh
+    public enum ItemSocketColor
+    {
+        SOCKET_COLOR_NONE = 0,
+        SOCKET_COLOR_META = 1,
+        SOCKET_COLOR_RED = 2,
+        SOCKET_COLOR_YELLOW = 4,
+        SOCKET_COLOR_BLUE = 8,
+        SOCKET_COLOR_ORANGE = SOCKET_COLOR_RED | SOCKET_COLOR_YELLOW,
+        SOCKET_COLOR_PURPLE = SOCKET_COLOR_RED | SOCKET_COLOR_BLUE,
+        SOCKET_COLOR_GREEN = SOCKET_COLOR_BLUE | SOCKET_COLOR_YELLOW,
+        SOCKET_COLOR_HYDRAULIC = 16,
+        SOCKET_COLOR_PRISMATIC = SOCKET_COLOR_RED | SOCKET_COLOR_YELLOW | SOCKET_COLOR_BLUE,
+        SOCKET_COLOR_COGWHEEL = 32,
+        // Legion relic data begins here
+        SOCKET_COLOR_IRON = 64,
+        SOCKET_COLOR_BLOOD = 128,
+        SOCKET_COLOR_SHADOW = 256,
+        SOCKET_COLOR_FEL = 512,
+        SOCKET_COLOR_ARCANE = 1024,
+        SOCKET_COLOR_FROST = 2048,
+        SOCKET_COLOR_FIRE = 4096,
+        SOCKET_COLOR_WATER = 8192,
+        SOCKET_COLOR_LIFE = 16384,
+        SOCKET_COLOR_WIND = 32768,
+        SOCKET_COLOR_HOLY = 65536,
+        SOCKET_COLOR_RED_PUNCHCARD = 131072,
+        SOCKET_COLOR_YELLOW_PUNCHCARD = 262144,
+        SOCKET_COLOR_BLUE_PUNCHCARD = 524288,
+        SOCKET_COLOR_MAX,
+        SOCKET_COLOR_RELIC = SOCKET_COLOR_IRON | SOCKET_COLOR_BLOOD | SOCKET_COLOR_SHADOW |
+                                            SOCKET_COLOR_FEL | SOCKET_COLOR_ARCANE | SOCKET_COLOR_FROST |
+                                            SOCKET_COLOR_FIRE | SOCKET_COLOR_WATER | SOCKET_COLOR_LIFE |
+                                            SOCKET_COLOR_WIND | SOCKET_COLOR_HOLY
     };
 }

--- a/SimcProfileParser/Model/RawData/SimcRawDataEnums.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawDataEnums.cs
@@ -61,7 +61,7 @@ namespace SimcProfileParser.Model.RawData
     };
 
     // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L456
-    enum ItemModType
+    public enum ItemModType
     {
         ITEM_MOD_NONE = -1,
         ITEM_MOD_MANA = 0,
@@ -212,7 +212,7 @@ namespace SimcProfileParser.Model.RawData
     };
 
     // from https://github.com/simulationcraft/simc/blob/shadowlands/engine/dbc/data_enums.hh#L337
-    enum InventoryType
+    public enum InventoryType
     {
         INVTYPE_NON_EQUIP = 0,
         INVTYPE_HEAD = 1,

--- a/SimcProfileParser/Model/RawData/SimcRawItem.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawItem.cs
@@ -22,8 +22,8 @@ namespace SimcProfileParser.Model.RawData
         /// <summary>
         /// This links to the InventoryType enum
         /// </summary>
-        public int InventoryType { get; set; }
-        public int ItemClass { get; set; }
+        public InventoryType InventoryType { get; set; }
+        public ItemClass ItemClass { get; set; }
         public int ItemSubClass { get; set; }
         public int BindType { get; set; }
         /// <summary>

--- a/SimcProfileParser/Model/RawData/SimcRawItem.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawItem.cs
@@ -18,7 +18,7 @@ namespace SimcProfileParser.Model.RawData
         /// <summary>
         /// This links to the Quality enum
         /// </summary>
-        public int Quality { get; set; }
+        public ItemQuality Quality { get; set; }
         /// <summary>
         /// This links to the InventoryType enum
         /// </summary>

--- a/SimcProfileParser/Model/RawData/SimcRawItem.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawItem.cs
@@ -33,9 +33,9 @@ namespace SimcProfileParser.Model.RawData
         public double DamageRange { get; set; }
         public double ItemModifier { get; set; }
         /// <summary>
-        /// TODO: Do we need this?
+        /// Index of the ItemMods array the items mods start at
         /// </summary>
-        public string DbcStats { get; set; }
+        public int DbcStats { get; set; }
         public uint DbcStatsCount { get; set; }
         public ulong RaceMask { get; set; }
         public uint ClassMask { get; set; }

--- a/SimcProfileParser/Model/RawData/SimcRawItemBonus.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawItemBonus.cs
@@ -11,7 +11,7 @@ namespace SimcProfileParser.Model.RawData
         /// <summary>
         /// TODO this is one of the enums, update it.
         /// </summary>
-        public uint Type { get; set; }
+        public ItemBonusType Type { get; set; }
         public int Value1 { get; set; }
         public int Value2 { get; set; }
         public int Value3 { get; set; }

--- a/SimcProfileParser/Model/RawData/SimcRawItemBonus.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawItemBonus.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SimcProfileParser.Model.RawData
+{
+    class SimcRawItemBonus
+    {
+        public uint Id { get; set; }
+        public uint BonusId { get; set; }
+        /// <summary>
+        /// TODO this is one of the enums, update it.
+        /// </summary>
+        public uint Type { get; set; }
+        public int Value1 { get; set; }
+        public int Value2 { get; set; }
+        public int Value3 { get; set; }
+        public int Value4 { get; set; }
+        public uint Index { get; set; }
+    }
+}

--- a/SimcProfileParser/Model/RawData/SimcRawItemEffect.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawItemEffect.cs
@@ -6,15 +6,21 @@ namespace SimcProfileParser.Model.RawData
 {
     class SimcRawItemEffect
     {
-        public int SpellTriggerType { get; set; }
-        public int SpellId { get; set; }
-        public int CooldownDuration { get; set; }
+        public uint Id { get; set; }
+        public uint SpellId { get; set; }
+        public uint ItemId { get; set; }
+        public int Index { get; set; }
+        /// <summary>
+        /// This could be spell trigger type?
+        /// </summary>
+        public int Type { get; set; }
         public int CooldownGroup { get; set; }
+        public int CooldownDuration { get; set; }
         public int CooldownGroupDuration { get; set; }
 
         public override string ToString()
         {
-            return $@"{SpellTriggerType}, {SpellId}, {CooldownDuration}, {CooldownGroup}, {CooldownGroupDuration}";
+            return $@"{Id}, {SpellId}, {ItemId}, {Index}, {Type}, {CooldownGroup}, {CooldownDuration}, {CooldownGroupDuration}";
         }
     }
 }

--- a/SimcProfileParser/Model/RawData/SimcRawItemMod.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawItemMod.cs
@@ -16,7 +16,7 @@ namespace SimcProfileParser.Model.RawData
         /// 62	ITEM_MOD_LEECH_RATING
         /// 
         /// </summary>
-        public int ModType { get; set; }
+        public ItemModType ModType { get; set; }
         public int StatAllocation { get; set; }
         public double SocketMultiplier { get; set; }
 

--- a/SimcProfileParser/Model/SimcItem.cs
+++ b/SimcProfileParser/Model/SimcItem.cs
@@ -1,0 +1,46 @@
+﻿using SimcProfileParser.Model.RawData;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SimcProfileParser.Model
+{
+    public class SimcItem
+    {
+        public uint ItemId { get; set; }
+        public uint ItemLevel { get; set; }
+        public List<SimcItemMod> Mods { get; set; }
+        public int SlotType { get; set; }
+        public int Quality { get; internal set; }
+        public InventoryType InventoryType { get; internal set; }
+
+        public SimcItem()
+        {
+            Mods = new List<SimcItemMod>();
+            InventoryType = InventoryType.INVTYPE_NON_EQUIP;
+        }
+
+        /// <summary>
+        /// Create or update the mod for the relevant stat
+        /// </summary>
+        /// <param name="stat"></param>
+        /// <param name="amount"></param>
+        internal void AddModRatingAmount(ItemModType stat, int amount)
+        {
+            var mod = Mods.Where(m => m.Type == stat).FirstOrDefault();
+
+            if (mod == null)
+            {
+                mod = new SimcItemMod
+                {
+                    Type = stat
+                };
+                Mods.Add(mod);
+            }
+
+            mod.StatRating += amount;
+
+        }
+    }
+}

--- a/SimcProfileParser/Model/SimcItem.cs
+++ b/SimcProfileParser/Model/SimcItem.cs
@@ -9,38 +9,19 @@ namespace SimcProfileParser.Model
     public class SimcItem
     {
         public uint ItemId { get; set; }
-        public uint ItemLevel { get; set; }
+        public int ItemLevel { get; set; }
         public List<SimcItemMod> Mods { get; set; }
+        public List<ItemSocketColor> Sockets { get; set; }
         public int SlotType { get; set; }
-        public int Quality { get; internal set; }
+        public ItemQuality Quality { get; internal set; }
         public InventoryType InventoryType { get; internal set; }
+        public string Name { get; set; }
 
         public SimcItem()
         {
             Mods = new List<SimcItemMod>();
+            Sockets = new List<ItemSocketColor>();
             InventoryType = InventoryType.INVTYPE_NON_EQUIP;
-        }
-
-        /// <summary>
-        /// Create or update the mod for the relevant stat
-        /// </summary>
-        /// <param name="stat"></param>
-        /// <param name="amount"></param>
-        internal void AddModRatingAmount(ItemModType stat, int amount)
-        {
-            var mod = Mods.Where(m => m.Type == stat).FirstOrDefault();
-
-            if (mod == null)
-            {
-                mod = new SimcItemMod
-                {
-                    Type = stat
-                };
-                Mods.Add(mod);
-            }
-
-            mod.StatRating += amount;
-
         }
     }
 }

--- a/SimcProfileParser/Model/SimcItem.cs
+++ b/SimcProfileParser/Model/SimcItem.cs
@@ -8,20 +8,26 @@ namespace SimcProfileParser.Model
 {
     public class SimcItem
     {
-        public uint ItemId { get; set; }
-        public int ItemLevel { get; set; }
-        public List<SimcItemMod> Mods { get; set; }
-        public List<ItemSocketColor> Sockets { get; set; }
-        public int SlotType { get; set; }
+        public uint ItemId { get; internal set; }
+        public string Name { get; internal set; }
+
+        public int ItemLevel { get; internal set; }
         public ItemQuality Quality { get; internal set; }
+
+        public List<SimcItemMod> Mods { get; internal set; }
+        public List<ItemSocketColor> Sockets { get; internal set; }
+
         public InventoryType InventoryType { get; internal set; }
-        public string Name { get; set; }
+        public ItemClass ItemClass { get; internal set; }
+        public int ItemSubClass { get; internal set; }
+
 
         public SimcItem()
         {
             Mods = new List<SimcItemMod>();
             Sockets = new List<ItemSocketColor>();
             InventoryType = InventoryType.INVTYPE_NON_EQUIP;
+            ItemClass = ItemClass.ITEM_CLASS_MISC; // Not a great default but at least its not used
         }
     }
 }

--- a/SimcProfileParser/Model/SimcItemMod.cs
+++ b/SimcProfileParser/Model/SimcItemMod.cs
@@ -1,0 +1,24 @@
+﻿using SimcProfileParser.Model.RawData;
+
+namespace SimcProfileParser.Model
+{
+    public class SimcItemMod
+    {
+        public ItemModType Type { get; set; }
+        public int RawStatAllocation { get; set; }
+        /// <summary>
+        /// Calculated actual value of the stat on this item
+        /// </summary>
+        public int StatRating { get; set; }
+
+        public SimcItemMod()
+        {
+            Type = ItemModType.ITEM_MOD_NONE;
+        }
+
+        public override string ToString()
+        {
+            return $@"{Type} ({RawStatAllocation}) Rating: {StatRating}";
+        }
+    }
+}

--- a/SimcProfileParser/SimcItemCreationService.cs
+++ b/SimcProfileParser/SimcItemCreationService.cs
@@ -1,0 +1,212 @@
+﻿using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SimcProfileParser.DataSync;
+using SimcProfileParser.Interfaces.DataSync;
+using SimcProfileParser.Model;
+using SimcProfileParser.Model.Profile;
+using SimcProfileParser.Model.RawData;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace SimcProfileParser
+{
+    public class SimcItemCreationService
+    {
+        private readonly ICacheService _cacheService;
+        private readonly ILogger _logger;
+
+        public SimcItemCreationService(ICacheService cacheService,
+            ILogger logger = null)
+        {
+            _cacheService = cacheService;
+            _logger = logger;
+
+            _cacheService.RegisterFileConfiguration(Model.DataSync.SimcFileType.ItemDataInc,
+                "ItemData.raw",
+                "https://raw.githubusercontent.com/simulationcraft/simc/shadowlands/engine/dbc/generated/item_data.inc"
+                );
+        }
+
+        internal object CreateItemsFromProfile(SimcParsedProfile parsedProfile)
+        {
+            var items = new List<SimcItem>();
+
+            foreach(var parsedItemData in parsedProfile.Items)
+            {
+                var item = CreateItem(parsedItemData);
+                items.Add(item);
+            }
+
+            return items;
+        }
+
+        internal SimcItem CreateItem(SimcParsedItem parsedItemData)
+        {
+            var rawItemData = GetRawItemData(parsedItemData.ItemId);
+
+            // Setup the item
+            var item = new SimcItem
+            {
+                Name = rawItemData.Name,
+                ItemId = rawItemData.Id
+            };
+
+            foreach(var socketColour in rawItemData.SocketColour)
+            {
+                item.Sockets.Add((ItemSocketColor)socketColour);
+            }
+
+            AddItemLevel(item, rawItemData.ItemLevel);
+            SetItemQuality(item, rawItemData.Quality);
+
+            // Now add the base mods
+            foreach (var mod in rawItemData.ItemMods)
+            {
+                if (mod.SocketMultiplier > 0)
+                    throw new NotImplementedException("Socket Multiplier not yet implemented");
+                AddItemMod(item, mod.ModType, mod.StatAllocation);
+            }
+
+            ProcessBonusIds(item, parsedItemData.BonusIds);
+
+            return item;
+        }
+
+        internal void ProcessBonusIds(SimcItem item, IReadOnlyCollection<int> bonusIds)
+        {
+            var bonusData = File.ReadAllText(Path.Combine(
+                    AppDomain.CurrentDomain.BaseDirectory,
+                    "SimcProfileParserData",
+                    "ItemBonusData.json")
+                );
+
+            var bonuses = JsonConvert.DeserializeObject<List<SimcRawItemBonus>>(bonusData);
+
+            // Go through each of the bonus IDs on the item
+            foreach (var bonusId in bonusIds)
+            {
+                // Find the bonus data for this bonus id
+                var bonusEntries = bonuses.Where(b => b.BonusId == bonusId);
+
+                if (bonusEntries == null)
+                    continue;
+
+                // Process the bonus data
+                foreach (var entry in bonusEntries)
+                {
+                    // From item_database::apply_item_bonus
+                    switch (entry.Type)
+                    {
+                        case ItemBonusType.ITEM_BONUS_ILEVEL:
+                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adding {entry.Value1} ilvl to {item.ItemLevel} => {item.ItemLevel + entry.Value1}");
+                            AddItemLevel(item, entry.Value1);
+                            break;
+
+                        case ItemBonusType.ITEM_BONUS_MOD:
+                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adding {entry.Value1} with more alloc: {entry.Value2}");
+                            AddItemMod(item, (ItemModType)entry.Value1, entry.Value2);
+                            break;
+
+                        case ItemBonusType.ITEM_BONUS_QUALITY:
+                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adjusting quality from {item.Quality} to {(ItemQuality)entry.Value1} ({entry.Value1})");
+                            SetItemQuality(item, (ItemQuality)entry.Value1);
+                            break;
+
+                        case ItemBonusType.ITEM_BONUS_SOCKET:
+                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adding {entry.Value1} sockets of type {entry.Value2}");
+                            AddItemSockets(item, entry.Value1, (ItemSocketColor)entry.Value2);
+                            break;
+
+                        case ItemBonusType.ITEM_BONUS_ADD_ITEM_EFFECT:
+                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adding effect {entry.Value1}");
+                            AddItemEffect(item, entry.Value1);
+                            break;
+
+                        // Unused bonustypes:
+                        case ItemBonusType.ITEM_BONUS_DESC:
+                        case ItemBonusType.ITEM_BONUS_SUFFIX:
+                            break;
+
+                        default:
+                            var entryString = JsonConvert.SerializeObject(entry);
+                            _logger?.LogTrace($"[{item.ItemId}] Unknown bonus entry: {entry.Type} ({bonusId}): {entryString}");
+                            break;
+                    }
+                }
+            }
+        }
+
+        internal void AddItemMod(SimcItem item, ItemModType modType, int statAllocation)
+        {
+            var newMod = new SimcItemMod();
+
+            newMod.Type = modType;
+            newMod.RawStatAllocation += statAllocation;
+
+            item.Mods.Add(newMod);
+        }
+
+        internal void AddItemSockets(SimcItem item, int numSockets, ItemSocketColor socketColor)
+        {
+            // Based on item_database::apply_item_bonus case ITEM_BONUS_SOCKET:
+            // This original method just adds colours to existing sockets.
+            var addedSockets = 0;
+            // Basically just loop through each of the sockets on the item and attempt to add colours
+            for (var i = 0; i < item.Sockets.Count && addedSockets < numSockets; i++)
+            {
+                // Can't add colours if there are no uncoloured sockets left
+                if (item.Sockets.Where(s => s == ItemSocketColor.SOCKET_COLOR_NONE).Count() > 0)
+                {
+                    var socket = item.Sockets.Where(s => s == ItemSocketColor.SOCKET_COLOR_NONE).FirstOrDefault();
+                    socket = socketColor;
+                    addedSockets++;
+                }
+                else
+                    _logger?.LogError($"Trying to apply a colour to a socket, but no sockets left.");
+            }
+        }
+
+        internal void SetItemQuality(SimcItem item, ItemQuality newQuality)
+        {
+            item.Quality = newQuality;
+        }
+
+        internal void AddItemLevel(SimcItem item, int newItemLevel)
+        {
+            item.ItemLevel = newItemLevel;
+        }
+
+        internal void AddItemEffect(SimcItem item, int effectId)
+        {
+            _logger?.LogError($"No item effect found when adding {effectId} to {item.ItemId}");
+        }
+
+        // TODO This is a hot mess. Need a service to retrieve data from these generated files.
+        internal SimcRawItem GetRawItemData(uint itemId)
+        {
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+
+            var rawItem = new SimcRawItem();
+
+            var itemData = File.ReadAllText(Path.Combine(
+                    AppDomain.CurrentDomain.BaseDirectory,
+                    "SimcProfileParserData",
+                    "ItemData.json")
+                );
+
+            var items = JsonConvert.DeserializeObject<List<SimcRawItem>>(itemData);
+
+            rawItem = items.Where(i => i.Id == itemId).FirstOrDefault();
+
+            sw.Stop();
+            _logger?.LogDebug($"Loading ItemData.json took {sw.ElapsedMilliseconds}ms ({items.Count} items)");
+
+            return rawItem;
+        }
+    }
+}

--- a/SimcProfileParser/SimcParserService.cs
+++ b/SimcProfileParser/SimcParserService.cs
@@ -466,7 +466,7 @@ namespace SimcProfileParser
                 switch (kvp[0])
                 {
                     case "id":
-                        if (!int.TryParse(kvp[1], out int itemId))
+                        if (!uint.TryParse(kvp[1], out uint itemId))
                         {
                             _logger?.LogWarning($"Unable to get itemid ({part}) from string {line.RawLine}");
                             continue;

--- a/SimcProfileParser/SimcParserService.cs
+++ b/SimcProfileParser/SimcParserService.cs
@@ -386,7 +386,7 @@ namespace SimcProfileParser
                         }
                         else
                         {
-                            _logger.LogWarning($"Unable to parse soulbind spell or conduit from part ({part}) in: {line.CleanLine}");
+                            _logger?.LogWarning($"Unable to parse soulbind spell or conduit from part ({part}) in: {line.CleanLine}");
                         }
                     }
                 }


### PR DESCRIPTION
This is basic item creation only, base primary, secondary stats and stamina.

Includes a caching layer to download the latest data files and some in-memory caching to speed up repeat access.

Some test coverage for core concepts

Api is still under development and will change in a future release.

Closes #14,  Closes #15, Closes #16, Closes #10