### PR TITLE
Moved powers to an enumerable dictionary

### DIFF
--- a/SimcProfileParser.Tests/SimcSpellCreationServiceTests.cs
+++ b/SimcProfileParser.Tests/SimcSpellCreationServiceTests.cs
@@ -117,6 +117,26 @@ namespace SimcProfileParser.Tests
         }
 
         [Test]
+        public async Task SSC_Creates_Player_Spell_With_Power()
+        {
+            // Arrange
+            var spellOptions = new SimcSpellOptions()
+            {
+                SpellId = 274740,
+                PlayerLevel = 60
+            };
+
+            // Act
+            var spell = await _spellCreationService.GeneratePlayerSpellAsync(spellOptions);
+
+            // Assert
+            Assert.IsNotNull(spell);
+            Assert.IsNotNull(spell.Effects);
+            Assert.AreEqual(1.32, spell.Effects[0].Coefficient);
+            Assert.AreEqual(95, spell.ScaleBudget);
+        }
+
+        [Test]
         public async Task SSC_Creates_Player_Spell_Raw()
         {
             // Arrange
@@ -138,14 +158,18 @@ namespace SimcProfileParser.Tests
         {
             // Arrange
             var playerLevel = 60u;
-            var spellId = 2061u;
+            var spellId = 589u;
 
             // Act
             var spell = await _spellCreationService.GeneratePlayerSpellAsync(playerLevel, spellId);
 
             // Assert
             Assert.IsNotNull(spell);
-            Assert.AreEqual(3.6, spell.PowerCost);
+            Assert.IsNotNull(spell.PowerCosts);
+            Assert.LessOrEqual(2, spell.PowerCosts.Count);
+            Assert.LessOrEqual(1.2, spell.PowerCosts.Skip(1).First().Value);
+            Assert.LessOrEqual(137031, spell.PowerCosts.Skip(1).First().Key);
+
         }
 
         [Test]

--- a/SimcProfileParser/Model/Generated/SimcSpell.cs
+++ b/SimcProfileParser/Model/Generated/SimcSpell.cs
@@ -35,11 +35,11 @@ namespace SimcProfileParser.Model.Generated
         public double CombatRatingMultiplier { get; internal set; }
         /// <summary>
         /// This is the PercentCost from the spellpower_data_t (SimcRawSpellPower)
-        /// This may need to be turned into an object, or even a list of objects to 
-        /// properly capture all of the relevant power costs if they're needed for
-        /// other purposes. Just getting percent mana is fine for our purposes now.
+        /// This is a list of percentage power costs that have a key relating to the AuraID 
+        /// that modifies this power usage. For example holy priest aura id is 137031. 
+        /// Just getting percent mana is fine for our purposes now.
         /// </summary>
-        public double PowerCost { get; internal set; }
+        public Dictionary<uint, double> PowerCosts { get; internal set; }
 
         /// <summary>
         /// Set if this spell is a conduit
@@ -56,6 +56,7 @@ namespace SimcProfileParser.Model.Generated
             Effects = new List<SimcSpellEffect>();
             RppmModifiers = new List<SimcSpellRppmModifier>();
             ConduitRanks = new Dictionary<uint, double>();
+            PowerCosts = new Dictionary<uint, double>();
         }
     }
 }

--- a/SimcProfileParser/SimcProfileParser.csproj
+++ b/SimcProfileParser/SimcProfileParser.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.2.0.0</Version>
+    <Version>0.2.1.0</Version>
     <Authors>Mechanical Priest</Authors>
     <Company>Mechanical Priest</Company>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
@@ -18,8 +18,8 @@
     <Title>Simc Profile Parser</Title>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>packageIcon.png</PackageIcon>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <AssemblyVersion>0.2.1.0</AssemblyVersion>
+    <FileVersion>0.2.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SimcProfileParser/SimcSpellCreationService.cs
+++ b/SimcProfileParser/SimcSpellCreationService.cs
@@ -64,8 +64,6 @@ namespace SimcProfileParser
                 budget = scaledValue;
             }
 
-            var powerCostPercent = spellData.SpellPowers.FirstOrDefault()?.PercentCost;
-
             var itemSpell = new SimcSpell()
             {
                 SpellId = spellData.Id,
@@ -87,9 +85,14 @@ namespace SimcProfileParser
                 InternalCooldown = spellData.InternalCooldown,
                 Rppm = spellData.Rppm,
                 CastTime = spellData.CastTime,
-                ScaleBudget = budget,
-                PowerCost = powerCostPercent.HasValue ? powerCostPercent.Value : 0
+                ScaleBudget = budget
             };
+
+            // Add power costs
+            foreach(var power in spellData.SpellPowers)
+            {
+                itemSpell.PowerCosts.Add(power.AuraId, power.PercentCost);
+            }
 
             // Add the RPPM modifiers
             var rppmModifiers = await _simcUtilityService.GetSpellRppmModifiersAsync(spellData.Id);
@@ -218,8 +221,6 @@ namespace SimcProfileParser
                 _logger?.LogError($"ilvl scaling from spell flags not yet implemented. Spell: {spellData.Id}");
             }
 
-            var powerCostPercent = spellData.SpellPowers.FirstOrDefault()?.PercentCost;
-
             var itemSpell = new SimcSpell()
             {
                 SpellId = spellData.Id,
@@ -242,9 +243,14 @@ namespace SimcProfileParser
                 Rppm = spellData.Rppm,
                 CastTime = spellData.CastTime,
                 ScaleBudget = budget,
-                CombatRatingMultiplier = multi,
-                PowerCost = powerCostPercent.HasValue ? powerCostPercent.Value : 0
+                CombatRatingMultiplier = multi
             };
+
+            // Add power costs
+            foreach (var power in spellData.SpellPowers)
+            {
+                itemSpell.PowerCosts.Add(power.AuraId, power.PercentCost);
+            }
 
             // Add the RPPM modifiers
             var rppmModifiers = await _simcUtilityService.GetSpellRppmModifiersAsync(spellData.Id);


### PR DESCRIPTION
Moved powers to an enumerable dictionary to store multiple power options per spell. Relevant for shared priest spells with different mana costs per spec. Fixes #56