### PR TITLE
Temporary fix for item scaling not working

### DIFF
--- a/SimcProfileParser.Tests/RawData/Alfouhk.simc
+++ b/SimcProfileParser.Tests/RawData/Alfouhk.simc
@@ -229,9 +229,6 @@ trinket2=,id=177149,bonus_id=6938/607,drop_level=50
 # 7th Legionnaire's Wand (138)
 # main_hand=,id=177135,bonus_id=6938,drop_level=50
 #
-# Battle Tested Staff (151)
-# main_hand=,id=183090
-#
 # Sinful Aspirant's Staff (158)
 # main_hand=,id=178473,bonus_id=6801/1472/6616
 #

--- a/SimcProfileParser.Tests/SimcGenerationServiceIntegrationTests.cs
+++ b/SimcProfileParser.Tests/SimcGenerationServiceIntegrationTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Serilog;
 using SimcProfileParser.Model.Generated;
 using SimcProfileParser.Model.RawData;
 using System.Collections.Generic;
@@ -16,7 +18,18 @@ namespace SimcProfileParser.Tests
         [OneTimeSetUp]
         public async Task Init()
         {
-            _sgs = new SimcGenerationService();
+            // Configure Logging
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.FromLogContext()
+                .WriteTo.File("logs" + Path.DirectorySeparatorChar + "SimcProfileParser.log", rollingInterval: RollingInterval.Day)
+                .CreateLogger();
+
+            var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddSerilog()
+                .AddFilter(level => level >= LogLevel.Trace));
+
+            _sgs = new SimcGenerationService(loggerFactory);
 
             var testFile = @"RawData" + Path.DirectorySeparatorChar + "Ardaysauk.simc";
             var testFileContents = await File.ReadAllLinesAsync(testFile);

--- a/SimcProfileParser/SimcItemCreationService.cs
+++ b/SimcProfileParser/SimcItemCreationService.cs
@@ -235,32 +235,39 @@ namespace SimcProfileParser
                     switch (entry.Type)
                     {
                         case ItemBonusType.ITEM_BONUS_ILEVEL:
-                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adding {entry.Value1} ilvl to {item.ItemLevel} => {item.ItemLevel + entry.Value1}");
+                            if (bonusIds.Contains(6652))
+                            {
+                                _logger?.LogDebug($"[{item.ItemId}] [{bonusId}:{entry.Type}] Item {item.Name} SKIPPING adding {entry.Value1} " +
+                                    $"ilvl to {item.ItemLevel} => {item.ItemLevel + entry.Value1} due to presence of bonusId 6652 (bug #68.)");
+                                break; // Bug fix for Simc#5490 (#68) - invalid item scaling on unnatural items
+                            }
+
+                            _logger?.LogDebug($"[{item.ItemId}] [{bonusId}:{entry.Type}] Item {item.Name} adding {entry.Value1} ilvl to {item.ItemLevel} => {item.ItemLevel + entry.Value1}");
                             AddItemLevel(item, entry.Value1);
                             break;
 
                         case ItemBonusType.ITEM_BONUS_MOD:
-                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adding {entry.Value1} with more alloc: {entry.Value2}");
+                            _logger?.LogDebug($"[{item.ItemId}] [{bonusId}:{entry.Type}] Item {item.Name} adding {entry.Value1} with more alloc: {entry.Value2}");
                             AddItemMod(item, (ItemModType)entry.Value1, entry.Value2);
                             break;
 
                         case ItemBonusType.ITEM_BONUS_QUALITY:
-                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adjusting quality from {item.Quality} to {(ItemQuality)entry.Value1} ({entry.Value1})");
+                            _logger?.LogDebug($"[{item.ItemId}] [{bonusId}:{entry.Type}] Item {item.Name} adjusting quality from {item.Quality} to {(ItemQuality)entry.Value1} ({entry.Value1})");
                             SetItemQuality(item, (ItemQuality)entry.Value1);
                             break;
 
                         case ItemBonusType.ITEM_BONUS_SOCKET:
-                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adding {entry.Value1} sockets of type {entry.Value2}");
+                            _logger?.LogDebug($"[{item.ItemId}] [{bonusId}:{entry.Type}] Item {item.Name} adding {entry.Value1} sockets of type {entry.Value2}");
                             AddItemSockets(item, entry.Value1, (ItemSocketColor)entry.Value2);
                             break;
 
                         case ItemBonusType.ITEM_BONUS_ADD_ITEM_EFFECT:
-                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adding effect {entry.Value1}");
+                            _logger?.LogDebug($"[{item.ItemId}] [{bonusId}:{entry.Type}] Item {item.Name} adding effect {entry.Value1}");
                             await AddItemEffect(item, entry.Value1);
                             break;
 
                         case ItemBonusType.ITEM_BONUS_SCALING_2:
-                            _logger?.LogDebug($"[{item.ItemId}] Item {item.Name} adding item scaling {entry.Value4} from {dropLevel}");
+                            _logger?.LogDebug($"[{item.ItemId}] [{bonusId}:{entry.Type}] Item {item.Name} adding item scaling {entry.Value4} from {dropLevel}");
                             await AddBonusScalingAsync(item, entry.Value4, dropLevel);
                             break;
 
@@ -271,7 +278,7 @@ namespace SimcProfileParser
 
                         default:
                             var entryString = JsonConvert.SerializeObject(entry);
-                            _logger?.LogTrace($"[{item.ItemId}] Unknown bonus entry: {entry.Type} ({bonusId}): {entryString}");
+                            _logger?.LogTrace($"[{item.ItemId}] [{bonusId}:{entry.Type}] Unknown bonus entry: {entry.Type} ({bonusId}): {entryString}");
                             break;
                     }
                 }
@@ -408,8 +415,6 @@ namespace SimcProfileParser
 
             _logger?.LogError($"Adding item effect {effectId} to {item.ItemId} (SpellId: {itemEffect.SpellId})");
             await AddSpellEffectAsync(item, itemEffect);
-
-
         }
     }
 }


### PR DESCRIPTION
Based on a recent commit https://github.com/simulationcraft/simc/commit/eccd6195c7c9794443f028225782d6e521e6023e on the simc repo to try and temporarily fix the issue with "unnatural" items (created at specific item level on vendors & premade characters) causing scaling issues.

Related to #68 