### PR TITLE
Updated datatype of ProcFlags to match Simc

### DIFF
--- a/SimcProfileParser/DataSync/RawDataExtractionService.cs
+++ b/SimcProfileParser/DataSync/RawDataExtractionService.cs
@@ -631,7 +631,7 @@ namespace SimcProfileParser.DataSync
                     spell.ProcCharges = Convert.ToInt32(data[25]);
 
                     // 26 is proc chance
-                    spell.ProcFlags = Convert.ToUInt32(data[26]);
+                    spell.ProcFlags = Convert.ToUInt64(data[26]);
 
                     // 27 is icd
                     spell.InternalCooldown = Convert.ToUInt32(data[27]);

--- a/SimcProfileParser/Model/RawData/SimcRawSpell.cs
+++ b/SimcProfileParser/Model/RawData/SimcRawSpell.cs
@@ -56,7 +56,7 @@ namespace SimcProfileParser.Model.RawData
         public uint MaxStack { get; set; }
         public uint ProcChance { get; set; }
         public int ProcCharges { get; set; }
-        public uint ProcFlags { get; set; }
+        public ulong ProcFlags { get; set; }
         public uint InternalCooldown { get; set; }
         public double Rppm { get; set; }
 

--- a/SimcProfileParser/SimcProfileParser.csproj
+++ b/SimcProfileParser/SimcProfileParser.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.1</Version>
+    <Version>1.4.1</Version>
     <Authors>Mechanical Priest</Authors>
     <Company>Mechanical Priest</Company>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/MechanicalPriest/SimcProfileParser</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/MechanicalPriest/SimcProfileParser</PackageProjectUrl>
-    <Copyright>Copyright © Mechanical Priest 2022</Copyright>
+    <Copyright>Copyright © Mechanical Priest 2023</Copyright>
     <Description>A library to parse the simc WoW addon results into usable objects.</Description>
     <Summary>A library to parse the simc WoW addon results into usable objects.</Summary>
     <PackageTags>simc warcraft</PackageTags>
@@ -18,8 +18,8 @@
     <Title>Simc Profile Parser</Title>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>packageIcon.png</PackageIcon>
-    <AssemblyVersion>1.3.1</AssemblyVersion>
-    <FileVersion>1.3.1</FileVersion>
+    <AssemblyVersion>1.4.1</AssemblyVersion>
+    <FileVersion>1.4.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Extended proc flag support was added to simc which changed the datatype of ProcFlags from unit32 to uint64.

Fixes #97 