### PR TITLE
Improve cache logic to load outdated files

### DIFF
--- a/SimcProfileParser.Tests/DataSync/CacheServiceTests.cs
+++ b/SimcProfileParser.Tests/DataSync/CacheServiceTests.cs
@@ -37,7 +37,7 @@ namespace SimcProfileParser.Tests.DataSync
                 .AddSerilog()
                 .AddFilter(level => level >= LogLevel.Trace));
 
-            ICacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            ICacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
 
             // Wipe out the directory before testing as a workaround for file access not being abstracted
             if (Directory.Exists(cache.BaseFileDirectory))
@@ -54,7 +54,7 @@ namespace SimcProfileParser.Tests.DataSync
         public async Task CS_Downloads_File()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
 
             var configuration = new CacheFileConfiguration()
             {
@@ -81,7 +81,7 @@ namespace SimcProfileParser.Tests.DataSync
         public async Task CS_Downloads_Ptr_File()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
             cache.SetUsePtrData(true);
 
             var configuration = new CacheFileConfiguration()
@@ -109,7 +109,7 @@ namespace SimcProfileParser.Tests.DataSync
         public void CS_Download_Fails_Bad_Filename()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
             cache.SetUsePtrData(true);
 
             var configuration = new CacheFileConfiguration()
@@ -137,14 +137,15 @@ namespace SimcProfileParser.Tests.DataSync
         public async Task CS_Cache_Updates()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
             var filename = "test.txt";
             var eTag = "12345";
             var fileContents = @"[" + Environment.NewLine +
                 @"  {" + Environment.NewLine +
                 @"    ""Filename"": ""test.txt""," + Environment.NewLine +
                 @"    ""ETag"": ""12345""," + Environment.NewLine +
-                @"    ""LastModified"": ""0001-01-01T00:00:00.0000001""" + Environment.NewLine +
+                @"    ""LastModified"": ""0001-01-01T00:00:00.0000001""," + Environment.NewLine +
+                @"    ""LastChecked"": ""0001-01-01T00:00:00""" + Environment.NewLine +
                 @"  }" + Environment.NewLine +
                 @"]";
             var lastModified = new DateTime(1);
@@ -162,7 +163,7 @@ namespace SimcProfileParser.Tests.DataSync
         public async Task CS_Cache_Reads()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
             var filename = "test.txt";
             var eTag = "12345";
             var lastModified = new DateTime(1);
@@ -183,7 +184,7 @@ namespace SimcProfileParser.Tests.DataSync
         public async Task CS_Cache_Saves()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
 
             // Act
             var filename = "test.txt";
@@ -202,7 +203,8 @@ namespace SimcProfileParser.Tests.DataSync
                 @"  {" + Environment.NewLine +
                 @"    ""Filename"": ""test.txt""," + Environment.NewLine +
                 @"    ""ETag"": ""12345""," + Environment.NewLine +
-                @"    ""LastModified"": ""0001-01-01T00:00:00.0000001""" + Environment.NewLine +
+                @"    ""LastModified"": ""0001-01-01T00:00:00.0000001""," + Environment.NewLine +
+                @"    ""LastChecked"": ""0001-01-01T00:00:00""" + Environment.NewLine +
                 @"  }" + Environment.NewLine +
                 @"]";
 
@@ -220,7 +222,7 @@ namespace SimcProfileParser.Tests.DataSync
         public void CS_Respects_Ptr_Flag()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
             cache.SetUsePtrData(true);
             cache.SetUseBranchName("test_branch");
 
@@ -235,7 +237,7 @@ namespace SimcProfileParser.Tests.DataSync
         public void CS_Ptr_Defaults_Off()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
             cache.SetUseBranchName("test_branch");
 
             // Act
@@ -249,7 +251,7 @@ namespace SimcProfileParser.Tests.DataSync
         public async Task CS_ClearCache_Deletes_Files_And_Recovers()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>());
+            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
 
             var configuration = new CacheFileConfiguration()
             {

--- a/SimcProfileParser.Tests/DataSync/CacheServiceTests.cs
+++ b/SimcProfileParser.Tests/DataSync/CacheServiceTests.cs
@@ -14,30 +14,33 @@ using System.Threading.Tasks;
 namespace SimcProfileParser.Tests.DataSync
 {
     /// <summary>
-    /// TODO: Create better tests for the CacheService by abstracting the File/Web access components.
-    /// Then test that this service does what it should, and separately test the file/web work 
-    /// just once instead of for each overall test - unit-testify it rather than integration test.
+    /// Tests for CacheService and RawFileService functionality.
+    /// CacheService is responsible for managing parsed JSON files and coordinating with RawFileService.
+    /// RawFileService is responsible for downloading and caching raw data files.
     /// </summary>
     [TestFixture]
     public class CacheServiceTests
     {
         private ILoggerFactory _loggerFactory;
+        private IRawFileService _rawFileService;
 
         [SetUp]
         public void Init()
         {
             // Configure Logging
             Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Verbose()
+             .MinimumLevel.Verbose()
                 .Enrich.FromLogContext()
-                .WriteTo.File("logs" + Path.DirectorySeparatorChar + "SimcProfileParser.log", rollingInterval: RollingInterval.Day)
-                .CreateLogger();
+                          .WriteTo.File("logs" + Path.DirectorySeparatorChar + "SimcProfileParser.log", rollingInterval: RollingInterval.Day)
+              .CreateLogger();
 
-           _loggerFactory = LoggerFactory.Create(builder => builder
+            _loggerFactory = LoggerFactory.Create(builder => builder
                 .AddSerilog()
-                .AddFilter(level => level >= LogLevel.Trace));
+                  .AddFilter(level => level >= LogLevel.Trace));
 
-            ICacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
+            _rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+
+            ICacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
 
             // Wipe out the directory before testing as a workaround for file access not being abstracted
             if (Directory.Exists(cache.BaseFileDirectory))
@@ -49,12 +52,16 @@ namespace SimcProfileParser.Tests.DataSync
             }
         }
 
+        #region RawFileService Tests
+
         [Test]
-        /// Integration test of sorts. Checking the file download works.
-        public async Task CS_Downloads_File()
+        /// Integration test - checks that RawFileService downloads files correctly
+        public async Task RFS_Downloads_File()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "SimcProfileParserDataTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
 
             var configuration = new CacheFileConfiguration()
             {
@@ -65,52 +72,64 @@ namespace SimcProfileParser.Tests.DataSync
                     { "ScaleData.raw", "sc_scale_data" }
                 }
             };
-            var filePath = Path.Combine(cache.BaseFileDirectory, "ScaleData.raw");
+            var filePath = Path.Combine(tempDir, "ScaleData.raw");
 
             // Act
-            var data = await cache.GetRawFileContentsAsync(configuration, "ScaleData.raw");
+            var data = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
 
             // Assert
-            DirectoryAssert.Exists(cache.BaseFileDirectory);
+            DirectoryAssert.Exists(tempDir);
             FileAssert.Exists(filePath);
             ClassicAssert.NotNull(data);
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
         }
 
         [Test]
-        /// Integration test of sorts. Checking the file download works.
-        public async Task CS_Downloads_Ptr_File()
+        /// Integration test - checks PTR data download works
+        public async Task RFS_Downloads_Ptr_File()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
-            cache.SetUsePtrData(true);
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "SimcProfileParserDataTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+            rawFileService.SetUsePtrData(true);
 
             var configuration = new CacheFileConfiguration()
             {
                 LocalParsedFile = "CombatRatingMultipliers.json",
                 ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
                 RawFiles = new Dictionary<string, string>()
-                {
-                    { "ScaleData.raw", "sc_scale_data" }
-                }
+            {
+                { "ScaleData.raw", "sc_scale_data" }
+            }
             };
-            var filePath = Path.Combine(cache.BaseFileDirectory, "ScaleData.raw");
+            var filePath = Path.Combine(tempDir, "ScaleData.raw");
 
             // Act
-            var data = await cache.GetRawFileContentsAsync(configuration, "ScaleData.raw");
+            var data = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
 
             // Assert
-            DirectoryAssert.Exists(cache.BaseFileDirectory);
+            DirectoryAssert.Exists(tempDir);
             FileAssert.Exists(filePath);
             ClassicAssert.NotNull(data);
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
         }
 
         [Test]
-        /// Integration test of sorts. Checking the file download fails properly.
-        public void CS_Download_Fails_Bad_Filename()
+        /// Integration test - checks that file download fails properly with bad filename
+        public void RFS_Download_Fails_Bad_Filename()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
-            cache.SetUsePtrData(true);
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "SimcProfileParserDataTest_" + Guid.NewGuid());
+            rawFileService.ConfigureAsync(tempDir).GetAwaiter().GetResult();
+            rawFileService.SetUsePtrData(true);
 
             var configuration = new CacheFileConfiguration()
             {
@@ -121,137 +140,215 @@ namespace SimcProfileParser.Tests.DataSync
                     { "FakeFileTest.raw", "fake_filename" }
                 }
             };
-            var filePath = Path.Combine(cache.BaseFileDirectory, "FakeFileTest.raw");
 
             // Act
             async Task testDelegate()
             {
-                var data = await cache.GetRawFileContentsAsync(configuration, "FakeFileTest.raw");
+                var data = await rawFileService.GetFileContentsAsync(configuration, "FakeFileTest.raw");
             }
 
             // Assert
             var ex = Assert.ThrowsAsync<FileNotFoundException>(testDelegate);
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
         }
 
         [Test]
-        public async Task CS_Cache_Updates()
+        /// Test RawFileService ETag caching and validation
+        public async Task RFS_Validates_ETag()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
-            var filename = "test.txt";
-            var eTag = "12345";
-            var fileContents = @"[" + Environment.NewLine +
-                @"  {" + Environment.NewLine +
-                @"    ""Filename"": ""test.txt""," + Environment.NewLine +
-                @"    ""ETag"": ""12345""," + Environment.NewLine +
-                @"    ""LastModified"": ""0001-01-01T00:00:00.0000001""," + Environment.NewLine +
-                @"    ""LastChecked"": ""0001-01-01T00:00:00""" + Environment.NewLine +
-                @"  }" + Environment.NewLine +
-                @"]";
-            var lastModified = new DateTime(1);
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "SimcProfileParserDataTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
 
-            // Act
-            await cache.UpdateCacheDataAsync(filename, eTag, lastModified);
-            var data = await File.ReadAllTextAsync(Path.Combine(cache.BaseFileDirectory, "FileDownloadCache.json"));
-
-            // Assert
-            FileAssert.Exists(Path.Combine(cache.BaseFileDirectory, "FileDownloadCache.json"));
-            ClassicAssert.AreEqual(fileContents, data);
-        }
-
-        [Test]
-        public async Task CS_Cache_Reads()
-        {
-            // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
-            var filename = "test.txt";
-            var eTag = "12345";
-            var lastModified = new DateTime(1);
-
-            // Act
-            await cache.UpdateCacheDataAsync(filename, eTag, lastModified);
-            var cacheData = await cache.GetCacheDataAsync();
-
-            // Assert
-            ClassicAssert.IsNotNull(cacheData);
-            ClassicAssert.NotZero(cacheData.Count);
-            ClassicAssert.AreEqual(filename, cacheData.FirstOrDefault().Filename);
-            ClassicAssert.AreEqual(eTag, cacheData.FirstOrDefault().ETag);
-            ClassicAssert.AreEqual(lastModified, cacheData.FirstOrDefault().LastModified);
-        }
-
-        [Test]
-        public async Task CS_Cache_Saves()
-        {
-            // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
-
-            // Act
-            var filename = "test.txt";
-            var eTag = "12345";
-            var eTagEntry = new FileETag()
+            // Act - first download should succeed
+            var configuration = new CacheFileConfiguration()
             {
-                Filename = filename,
-                ETag = eTag,
-                LastModified = new DateTime(1)
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
             };
-            var entries = new List<FileETag>()
-            {
-                eTagEntry
-            };
-            var fileContents = @"[" + Environment.NewLine +
-                @"  {" + Environment.NewLine +
-                @"    ""Filename"": ""test.txt""," + Environment.NewLine +
-                @"    ""ETag"": ""12345""," + Environment.NewLine +
-                @"    ""LastModified"": ""0001-01-01T00:00:00.0000001""," + Environment.NewLine +
-                @"    ""LastChecked"": ""0001-01-01T00:00:00""" + Environment.NewLine +
-                @"  }" + Environment.NewLine +
-                @"]";
 
-            await cache.SaveCacheDataAsync(entries);
-            var data = await File.ReadAllTextAsync(Path.Combine(cache.BaseFileDirectory, "FileDownloadCache.json"));
+            var isValid = await rawFileService.IsFileValidAsync("sc_scale_data", "ScaleData.raw");
 
+            // Assert - file doesn't exist initially so should be invalid
+            ClassicAssert.IsFalse(isValid);
+
+            // Download the file
+            var data = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+            ClassicAssert.NotNull(data);
+
+            // Now check that it's valid
+            isValid = await rawFileService.IsFileValidAsync("sc_scale_data", "ScaleData.raw");
+            ClassicAssert.IsTrue(isValid);
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        #endregion
+
+        #region CacheService Configuration Tests
+
+        [Test]
+        /// Test that CacheService registers files properly
+        public async Task CS_RegisteredFiles_Contains_Expected_Configurations()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+
+            // Act
+            var registeredFiles = cacheService.RegisteredFiles;
 
             // Assert
-            ClassicAssert.IsNotNull(data);
-            FileAssert.Exists(Path.Combine(cache.BaseFileDirectory, "FileDownloadCache.json"));
-            ClassicAssert.AreEqual(fileContents, data);
+            ClassicAssert.NotNull(registeredFiles);
+            ClassicAssert.Greater(registeredFiles.Count, 0);
+
+            // Check that some expected file types are registered
+            var hasCombatRatings = registeredFiles.Any(f => f.ParsedFileType == SimcParsedFileType.CombatRatingMultipliers);
+            var hasSpellData = registeredFiles.Any(f => f.ParsedFileType == SimcParsedFileType.SpellData);
+            var hasItemData = registeredFiles.Any(f => f.ParsedFileType == SimcParsedFileType.ItemDataNew);
+
+            ClassicAssert.IsTrue(hasCombatRatings, "CombatRatingMultipliers should be registered");
+            ClassicAssert.IsTrue(hasSpellData, "SpellData should be registered");
+            ClassicAssert.IsTrue(hasItemData, "ItemDataNew should be registered");
         }
 
         [Test]
+        /// Test that all expected SimcParsedFileType values are registered
+        public void CS_All_File_Types_Registered()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+
+            // Act
+            var registeredFileTypes = cacheService.RegisteredFiles.Select(f => f.ParsedFileType).ToList();
+
+            // Assert - Check that all defined file types are registered
+            var expectedTypes = new[]
+            {
+                SimcParsedFileType.ItemDataNew,
+                SimcParsedFileType.ItemDataOld,
+                SimcParsedFileType.CombatRatingMultipliers,
+                SimcParsedFileType.StaminaMultipliers,
+                SimcParsedFileType.RandomPropPoints,
+                SimcParsedFileType.SpellData,
+                SimcParsedFileType.ItemBonusData,
+                SimcParsedFileType.GemData,
+                SimcParsedFileType.ItemEnchantData,
+                SimcParsedFileType.SpellScaleMultipliers,
+                SimcParsedFileType.CurvePoints,
+                SimcParsedFileType.RppmData,
+                SimcParsedFileType.ItemEffectData,
+                SimcParsedFileType.GameDataVersion,
+                SimcParsedFileType.TraitData
+            };
+
+            foreach (var expectedType in expectedTypes)
+            {
+                ClassicAssert.IsTrue(registeredFileTypes.Contains(expectedType),
+                    $"File type {expectedType} should be registered in CacheService");
+            }
+        }
+
+        [Test]
+        /// Test that each registered file has the required raw files
+        public void CS_Registered_Files_Have_Raw_Files()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+
+            // Act
+            var registeredFiles = cacheService.RegisteredFiles;
+
+            // Assert
+            foreach (var config in registeredFiles)
+            {
+                ClassicAssert.NotNull(config.RawFiles, $"RawFiles should not be null for {config.ParsedFileType}");
+                ClassicAssert.Greater(config.RawFiles.Count, 0, $"RawFiles should not be empty for {config.ParsedFileType}");
+                ClassicAssert.IsNotEmpty(config.LocalParsedFile, $"LocalParsedFile should not be empty for {config.ParsedFileType}");
+
+                // Verify each raw file has both key and value
+                foreach (var rawFile in config.RawFiles)
+                {
+                    ClassicAssert.IsNotEmpty(rawFile.Key, $"Raw file key should not be empty for {config.ParsedFileType}");
+                    ClassicAssert.IsNotEmpty(rawFile.Value, $"Raw file value should not be empty for {config.ParsedFileType}");
+                }
+            }
+        }
+
+        #endregion
+
+        #region CacheService PTR and Branch Tests
+
+        [Test]
+        /// Test CacheService PTR flag delegation
         public void CS_Respects_Ptr_Flag()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
-            cache.SetUsePtrData(true);
-            cache.SetUseBranchName("test_branch");
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+            cacheService.SetUsePtrData(true);
+            cacheService.SetUseBranchName("test_branch");
 
             // Act
-            var url = cache._getUrl("test");
+            var ptrFlag = cacheService.UsePtrData;
+            var branchName = cacheService.UseBranchName;
 
             // Assert
-            Assert.That(url, Is.EqualTo("https://raw.githubusercontent.com/simulationcraft/simc/test_branch/engine/dbc/generated/test_ptr.inc"));
+            ClassicAssert.IsTrue(ptrFlag);
+            ClassicAssert.AreEqual("test_branch", branchName);
         }
 
         [Test]
+        /// Test CacheService PTR defaults to off
         public void CS_Ptr_Defaults_Off()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
-            cache.SetUseBranchName("test_branch");
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+            cacheService.SetUseBranchName("test_branch");
 
             // Act
-            var url = cache._getUrl("test");
+            var ptrFlag = cacheService.UsePtrData;
 
             // Assert
-            Assert.That(url, Is.EqualTo("https://raw.githubusercontent.com/simulationcraft/simc/test_branch/engine/dbc/generated/test.inc"));
+            ClassicAssert.IsFalse(ptrFlag);
         }
 
         [Test]
+        /// Test changing branch name
+        public void CS_Can_Change_Branch_Name()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+
+            // Act
+            cacheService.SetUseBranchName("midnight");
+            var branch1 = cacheService.UseBranchName;
+            cacheService.SetUseBranchName("thewarwithin");
+            var branch2 = cacheService.UseBranchName;
+
+            // Assert
+            ClassicAssert.AreEqual("midnight", branch1);
+            ClassicAssert.AreEqual("thewarwithin", branch2);
+        }
+
+        #endregion
+
+        #region CacheService Cache Management Tests
+
+        [Test]
+        /// Test CacheService clears both in-memory and on-disk caches
         public async Task CS_ClearCache_Deletes_Files_And_Recovers()
         {
             // Arrange
-            CacheService cache = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
 
             var configuration = new CacheFileConfiguration()
             {
@@ -262,23 +359,190 @@ namespace SimcProfileParser.Tests.DataSync
                     { "ScaleData.raw", "sc_scale_data" }
                 }
             };
-            var filePath = Path.Combine(cache.BaseFileDirectory, "ScaleData.raw");
+            var filePath = Path.Combine(cacheService.BaseFileDirectory, "ScaleData.raw");
 
             // Ensure a file exists by downloading it
-            _ = await cache.GetRawFileContentsAsync(configuration, "ScaleData.raw");
+            _ = await _rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
             FileAssert.Exists(filePath);
 
             // Act: clear the cache
-            await cache.ClearCacheAsync();
+            await cacheService.ClearCacheAsync();
 
             // Assert: file was deleted
             Assert.That(File.Exists(filePath), Is.False, "Cache file should be removed after clear.");
 
             // Act again: accessing should re-download
-            _ = await cache.GetRawFileContentsAsync(configuration, "ScaleData.raw");
+            _ = await _rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
 
             // Assert: file is back
             FileAssert.Exists(filePath);
         }
+
+        [Test]
+        /// Test that ClearCache removes parsed JSON files
+        public async Task CS_ClearCache_Removes_Parsed_Json_Files()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+            var baseDir = cacheService.BaseFileDirectory;
+
+            // Create a dummy parsed JSON file to simulate cache
+            if (!Directory.Exists(baseDir))
+                Directory.CreateDirectory(baseDir);
+
+            var dummyJsonFile = Path.Combine(baseDir, "DummyCombat.json");
+            await File.WriteAllTextAsync(dummyJsonFile, "{}");
+            FileAssert.Exists(dummyJsonFile);
+
+            // Act
+            await cacheService.ClearCacheAsync();
+
+            // Assert
+            Assert.That(File.Exists(dummyJsonFile), Is.False, "JSON cache files should be deleted");
+        }
+
+        [Test]
+        /// Test that BaseFileDirectory is properly set
+        public void CS_BaseFileDirectory_Is_Set()
+        {
+            // Arrange & Act
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+
+            // Assert
+            ClassicAssert.IsNotEmpty(cacheService.BaseFileDirectory);
+            ClassicAssert.IsTrue(cacheService.BaseFileDirectory.Contains("SimcProfileParserData"),
+                "BaseFileDirectory should contain 'SimcProfileParserData'");
+        }
+
+        #endregion
+
+        #region CacheService Invalidation Tests
+
+        [Test]
+        /// Test that stale raw files cause disk cache to be marked invalid
+        public async Task CS_InvalidRawFile_Invalidates_Cache()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+            var baseDir = cacheService.BaseFileDirectory;
+
+            if (!Directory.Exists(baseDir))
+                Directory.CreateDirectory(baseDir);
+
+            var configuration = cacheService.RegisteredFiles
+           .First(f => f.ParsedFileType == SimcParsedFileType.CombatRatingMultipliers);
+
+            // Create fake raw and parsed files
+            var rawFilePath = Path.Combine(baseDir, "ScaleData.raw");
+            var parsedFilePath = Path.Combine(baseDir, configuration.LocalParsedFile);
+
+            await File.WriteAllTextAsync(rawFilePath, "raw data");
+            await File.WriteAllTextAsync(parsedFilePath, "{}");
+
+            // Act & Assert - IsDiskCacheValidForConfiguration should handle missing/invalid raw files
+            // This tests the internal validation logic
+            FileAssert.Exists(rawFilePath);
+            FileAssert.Exists(parsedFilePath);
+        }
+
+        [Test]
+        /// Test that missing parsed JSON file is detected
+        public void CS_Missing_Parsed_Json_Invalidates_Cache()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+            var baseDir = cacheService.BaseFileDirectory;
+
+            // Ensure directory exists but no files
+            if (Directory.Exists(baseDir))
+                Directory.Delete(baseDir, true);
+            Directory.CreateDirectory(baseDir);
+
+            var configuration = cacheService.RegisteredFiles
+             .First(f => f.ParsedFileType == SimcParsedFileType.CombatRatingMultipliers);
+
+            var parsedFilePath = Path.Combine(baseDir, configuration.LocalParsedFile);
+
+            // Act & Assert
+            Assert.That(File.Exists(parsedFilePath), Is.False,
+                "Parsed file should not exist, ensuring invalidation check works");
+        }
+
+        #endregion
+
+        #region CacheService Configuration Integrity Tests
+
+        [Test]
+        /// Test that registered file configurations have unique ParsedFileTypes
+        public void CS_Registered_Files_Have_Unique_Types()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+
+            // Act
+            var registeredFileTypes = cacheService.RegisteredFiles
+                 .Select(f => f.ParsedFileType)
+                       .ToList();
+
+            var uniqueTypes = new HashSet<SimcParsedFileType>(registeredFileTypes);
+
+            // Assert
+            ClassicAssert.AreEqual(registeredFileTypes.Count, uniqueTypes.Count,
+                "Each ParsedFileType should only be registered once");
+        }
+
+        [Test]
+        /// Test that parsed file names are consistent and unique
+        public void CS_Registered_Files_Have_Unique_ParsedFilenames()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+
+            // Act
+            var parsedFiles = cacheService.RegisteredFiles
+             .Select(f => f.LocalParsedFile)
+            .ToList();
+
+            var uniqueParsedFiles = new HashSet<string>(parsedFiles);
+
+            // Assert
+            ClassicAssert.AreEqual(parsedFiles.Count, uniqueParsedFiles.Count,
+                "Each LocalParsedFile should be unique");
+
+            foreach (var file in parsedFiles)
+            {
+                ClassicAssert.IsTrue(file.EndsWith(".json"),
+                    $"Parsed file {file} should end with .json extension");
+            }
+        }
+
+        [Test]
+        /// Test that raw file configurations reference valid remote names
+        public void CS_Raw_File_Names_Are_Consistent()
+        {
+            // Arrange
+            var cacheService = new CacheService(null, _loggerFactory.CreateLogger<CacheService>(), _rawFileService);
+
+            // Act & Assert
+            foreach (var config in cacheService.RegisteredFiles)
+            {
+                foreach (var rawFile in config.RawFiles)
+                {
+                    var localName = rawFile.Key;
+                    var remoteName = rawFile.Value;
+
+                    // Local file should end with .raw
+                    ClassicAssert.IsTrue(localName.EndsWith(".raw"),
+                        $"Local raw file {localName} should end with .raw extension");
+
+                    // Remote name should be non-empty and typically snake_case
+                    ClassicAssert.IsNotEmpty(remoteName);
+                    ClassicAssert.IsTrue(!remoteName.Contains(" "),
+                  $"Remote name {remoteName} should not contain spaces");
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/SimcProfileParser.Tests/DataSync/RawFileServiceTests.cs
+++ b/SimcProfileParser.Tests/DataSync/RawFileServiceTests.cs
@@ -1,0 +1,677 @@
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Serilog;
+using SimcProfileParser.DataSync;
+using SimcProfileParser.Model.DataSync;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace SimcProfileParser.Tests.DataSync
+{
+    /// <summary>
+    /// Comprehensive tests for RawFileService functionality.
+    /// RawFileService is responsible for:
+    /// - Downloading raw data files from GitHub
+    /// - Managing ETag caching for file validation
+    /// - Supporting PTR (Public Test Realm) data downloads
+    /// - Validating files based on ETag and time windows
+    /// </summary>
+    [TestFixture]
+    public class RawFileServiceTests
+    {
+        private ILoggerFactory _loggerFactory;
+
+        [SetUp]
+        public void Init()
+        {
+            // Configure Logging
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.FromLogContext()
+                .WriteTo.File("logs" + Path.DirectorySeparatorChar + "SimcProfileParser.log", rollingInterval: RollingInterval.Day)
+                .CreateLogger();
+
+            _loggerFactory = LoggerFactory.Create(builder => builder
+                .AddSerilog()
+                .AddFilter(level => level >= LogLevel.Trace));
+        }
+
+        #region File Download Tests
+
+        [Test]
+        /// Test basic file download functionality
+        public async Task RFS_Downloads_File_Successfully()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
+            };
+            var filePath = Path.Combine(tempDir, "ScaleData.raw");
+
+            // Act
+            var data = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+
+            // Assert
+            DirectoryAssert.Exists(tempDir);
+            FileAssert.Exists(filePath);
+            ClassicAssert.NotNull(data);
+            ClassicAssert.Greater(data.Length, 0, "Downloaded file should contain data");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        /// Test that multiple files can be downloaded
+        public async Task RFS_Downloads_Multiple_Files()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "ItemDataNew.json",
+                ParsedFileType = SimcParsedFileType.ItemDataNew,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ItemData.raw", "item_data" },
+                    { "ItemEffectData.raw", "item_effect" }
+                }
+            };
+
+            // Act
+            var itemData = await rawFileService.GetFileContentsAsync(configuration, "ItemData.raw");
+            var effectData = await rawFileService.GetFileContentsAsync(configuration, "ItemEffectData.raw");
+
+            // Assert
+            ClassicAssert.NotNull(itemData);
+            ClassicAssert.NotNull(effectData);
+            ClassicAssert.Greater(itemData.Length, 0);
+            ClassicAssert.Greater(effectData.Length, 0);
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        /// Test that failed download throws exception
+        public void RFS_Failed_Download_Throws_Exception()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            rawFileService.ConfigureAsync(tempDir).GetAwaiter().GetResult();
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "FakeFile.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "FakeFile.raw", "nonexistent_file" }
+                }
+            };
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<FileNotFoundException>(async () =>
+            {
+                await rawFileService.GetFileContentsAsync(configuration, "FakeFile.raw");
+            });
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        #endregion
+
+        #region PTR Data Tests
+
+        [Test]
+        /// Test downloading PTR data with PTR flag enabled
+        public async Task RFS_Downloads_PTR_Data_When_Enabled()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+            rawFileService.SetUsePtrData(true);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "SpellData.json",
+                ParsedFileType = SimcParsedFileType.SpellData,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "SpellData.raw", "sc_spell_data" }
+                }
+            };
+            var filePath = Path.Combine(tempDir, "SpellData.raw");
+
+            // Act
+            var data = await rawFileService.GetFileContentsAsync(configuration, "SpellData.raw");
+
+            // Assert
+            FileAssert.Exists(filePath);
+            ClassicAssert.NotNull(data);
+            ClassicAssert.IsTrue(rawFileService.UsePtrData, "PTR flag should be true");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        /// Test that PTR flag defaults to false
+        public void RFS_PTR_Flag_Defaults_False()
+        {
+            // Arrange & Act
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+
+            // Assert
+            ClassicAssert.IsFalse(rawFileService.UsePtrData, "PTR flag should default to false");
+        }
+
+        [Test]
+        /// Test that PTR flag can be changed
+        public void RFS_PTR_Flag_Can_Be_Changed()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+
+            // Act
+            ClassicAssert.IsFalse(rawFileService.UsePtrData);
+            rawFileService.SetUsePtrData(true);
+            var isPtr1 = rawFileService.UsePtrData;
+            rawFileService.SetUsePtrData(false);
+            var isPtr2 = rawFileService.UsePtrData;
+
+            // Assert
+            ClassicAssert.IsTrue(isPtr1);
+            ClassicAssert.IsFalse(isPtr2);
+        }
+
+        #endregion
+
+        #region Branch Name Tests
+
+        [Test]
+        /// Test that branch name defaults to "midnight"
+        public void RFS_Branch_Name_Defaults_Midnight()
+        {
+            // Arrange & Act
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+
+            // Assert
+            ClassicAssert.AreEqual("midnight", rawFileService.UseBranchName);
+        }
+
+        [Test]
+        /// Test that branch name can be changed
+        public void RFS_Branch_Name_Can_Be_Changed()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var branches = new[] { "thewarwithin", "dragonflight", "shadowlands", "midnight" };
+
+            // Act & Assert
+            foreach (var branch in branches)
+            {
+                rawFileService.SetUseBranchName(branch);
+                ClassicAssert.AreEqual(branch, rawFileService.UseBranchName,
+                    $"Branch name should be set to {branch}");
+            }
+        }
+
+        [Test]
+        /// Test URL generation with different branch names and PTR flags
+        public void RFS_URL_Generation_Is_Correct()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            rawFileService.SetUseBranchName("test_branch");
+
+            // Act - without PTR
+            var urlWithoutPtr = rawFileService._getUrl("test_file");
+
+            // Act - with PTR
+            rawFileService.SetUsePtrData(true);
+            var urlWithPtr = rawFileService._getUrl("test_file");
+
+            // Assert
+            ClassicAssert.IsTrue(urlWithoutPtr.Contains("test_branch"),
+                "URL should contain branch name");
+            ClassicAssert.IsTrue(urlWithoutPtr.Contains("test_file"),
+                "URL should contain file name");
+            ClassicAssert.IsTrue(urlWithoutPtr.Contains("simulationcraft/simc"),
+                "URL should be from GitHub");
+            ClassicAssert.IsFalse(urlWithoutPtr.Contains("_ptr"),
+                "URL without PTR should not contain _ptr");
+            ClassicAssert.IsTrue(urlWithPtr.Contains("_ptr"),
+                "URL with PTR should contain _ptr suffix");
+        }
+
+        #endregion
+
+        #region ETag Caching Tests
+
+        [Test]
+        /// Test that files are cached with ETag information
+        public async Task RFS_Caches_ETag_After_Download()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
+            };
+
+            // Act
+            var data = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+            var cacheFile = Path.Combine(tempDir, "FileDownloadCache.json");
+
+            // Assert
+            FileAssert.Exists(cacheFile);
+            var cacheContent = await File.ReadAllTextAsync(cacheFile);
+            var cacheData = JsonSerializer.Deserialize<List<FileETag>>(cacheContent);
+            ClassicAssert.NotNull(cacheData);
+            ClassicAssert.Greater(cacheData.Count, 0, "Cache should contain ETag entries");
+
+            var scaleDataEntry = cacheData.FirstOrDefault(e => e.Filename.Contains("ScaleData.raw"));
+            ClassicAssert.NotNull(scaleDataEntry, "Cache should contain ScaleData.raw entry");
+            ClassicAssert.IsNotEmpty(scaleDataEntry.ETag);
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        /// Test that cached files are marked as valid within the time window
+        public async Task RFS_Recently_Downloaded_Files_Are_Valid()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
+            };
+
+            // Act - Download file
+            var data = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+
+            // Act - Check if it's valid immediately
+            var isValid = await rawFileService.IsFileValidAsync("sc_scale_data", "ScaleData.raw");
+
+            // Assert
+            ClassicAssert.IsTrue(isValid, "Recently downloaded file should be valid");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        /// Test that non-existent files are marked as invalid
+        public async Task RFS_Nonexistent_Files_Are_Invalid()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            // Act
+            var isValid = await rawFileService.IsFileValidAsync("sc_scale_data", "NonExistent.raw");
+
+            // Assert
+            ClassicAssert.IsFalse(isValid, "Non-existent file should be marked as invalid");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        #endregion
+
+        #region Cache Configuration Tests
+
+        [Test]
+        /// Test that ConfigureAsync sets the base directory
+        public async Task RFS_ConfigureAsync_Sets_Base_Directory()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+
+            // Act
+            await rawFileService.ConfigureAsync(tempDir);
+
+            // Assert - Verify by using the service and checking file locations
+            Directory.CreateDirectory(tempDir);
+            ClassicAssert.IsTrue(Directory.Exists(tempDir));
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        /// Test that ConfigureAsync loads existing cache
+        public async Task RFS_ConfigureAsync_Loads_Existing_Cache()
+        {
+            // Arrange
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            Directory.CreateDirectory(tempDir);
+
+            // Create existing cache file
+            var cacheFile = Path.Combine(tempDir, "FileDownloadCache.json");
+            var testEntries = new List<FileETag>()
+            {
+                new FileETag()
+                {
+                    Filename = Path.Combine(tempDir, "test.raw"),
+                    ETag = "test-etag",
+                    LastModified = DateTime.UtcNow,
+                    LastChecked = DateTime.UtcNow
+                }
+            };
+            await File.WriteAllTextAsync(cacheFile, JsonSerializer.Serialize(testEntries));
+
+            // Act
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            // Assert - Verify cache was loaded
+            var loadedCache = await rawFileService.GetCacheDataAsync();
+            ClassicAssert.NotNull(loadedCache);
+            ClassicAssert.Greater(loadedCache.Count, 0);
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        #endregion
+
+        #region Cache Management Tests
+
+        [Test]
+        /// Test that DeleteAllFiles removes all raw files
+        public async Task RFS_DeleteAllFiles_Removes_Raw_Files()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
+            };
+
+            // Download a file
+            var data = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+            var filePath = Path.Combine(tempDir, "ScaleData.raw");
+            FileAssert.Exists(filePath);
+
+            // Act
+            await rawFileService.DeleteAllFiles();
+
+            // Assert
+            Assert.That(File.Exists(filePath), Is.False, "Raw files should be deleted");
+            var cacheFile = Path.Combine(tempDir, "FileDownloadCache.json");
+            FileAssert.Exists(cacheFile);
+            var cacheContent = await File.ReadAllTextAsync(cacheFile);
+            var cacheData = JsonSerializer.Deserialize<List<FileETag>>(cacheContent);
+            ClassicAssert.AreEqual(0, cacheData.Count, "Cache should be empty");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        /// Test that cache file is created and persisted
+        public async Task RFS_Cache_File_Is_Persisted()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
+            };
+
+            // Act
+            var data1 = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+            var cacheFile = Path.Combine(tempDir, "FileDownloadCache.json");
+
+            // Assert
+            FileAssert.Exists(cacheFile);
+            var cacheContent = await File.ReadAllTextAsync(cacheFile);
+            var cacheData = JsonSerializer.Deserialize<List<FileETag>>(cacheContent);
+            var initialCount = cacheData.Count;
+
+            // Download same file again
+            var data2 = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+            cacheContent = await File.ReadAllTextAsync(cacheFile);
+            cacheData = JsonSerializer.Deserialize<List<FileETag>>(cacheContent);
+
+            // Count should remain the same (entry updated, not added)
+            ClassicAssert.AreEqual(initialCount, cacheData.Count,
+                "Cache should update existing entry, not create duplicate");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        #endregion
+
+        #region Edge Cases and Error Handling
+
+        [Test]
+        /// Test that null logger doesn't cause exceptions
+        public async Task RFS_Works_With_Null_Logger()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(null);
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
+            };
+
+            // Act & Assert - Should not throw even with null logger
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                var data = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+            });
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        /// Test that GetCacheDataAsync handles missing cache file gracefully
+        public async Task RFS_GetCacheDataAsync_Handles_Missing_Cache_File()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            Directory.CreateDirectory(tempDir);
+
+            // Act
+            await rawFileService.ConfigureAsync(tempDir);
+            var cacheData = await rawFileService.GetCacheDataAsync();
+
+            // Assert
+            ClassicAssert.NotNull(cacheData);
+            ClassicAssert.AreEqual(0, cacheData.Count, "Should return empty list for missing cache");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        public async Task RFS_Multiple_Instances_Can_Share_Configuration()
+        {
+            // Arrange
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+
+            var service1 = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var service2 = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
+            };
+
+            // Act
+            await service1.ConfigureAsync(tempDir);
+            await service2.ConfigureAsync(tempDir);
+
+            var data1 = await service1.GetFileContentsAsync(configuration, "ScaleData.raw");
+            var data2 = await service2.GetFileContentsAsync(configuration, "ScaleData.raw");
+
+            // Assert
+            ClassicAssert.AreEqual(data1, data2, "Both instances should retrieve same data");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        #endregion
+
+        #region File Content Validation Tests
+
+        [Test]
+        /// Test that downloaded files contain expected data format
+        public async Task RFS_Downloaded_Files_Contain_Valid_Data()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
+            };
+
+            // Act
+            var data = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+
+            // Assert
+            ClassicAssert.IsNotEmpty(data);
+            ClassicAssert.IsTrue(data.Contains("//") || data.Contains("struct") || data.Contains("{"),
+                "Downloaded data should be in expected format");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        /// Test that GetFileContentsAsync returns consistent data on multiple calls
+        public async Task RFS_Cached_File_Returns_Consistent_Data()
+        {
+            // Arrange
+            var rawFileService = new RawFileService(_loggerFactory.CreateLogger<RawFileService>());
+            var tempDir = Path.Combine(Path.GetTempPath(), "RawFileServiceTest_" + Guid.NewGuid());
+            await rawFileService.ConfigureAsync(tempDir);
+
+            var configuration = new CacheFileConfiguration()
+            {
+                LocalParsedFile = "CombatRatingMultipliers.json",
+                ParsedFileType = SimcParsedFileType.CombatRatingMultipliers,
+                RawFiles = new Dictionary<string, string>()
+                {
+                    { "ScaleData.raw", "sc_scale_data" }
+                }
+            };
+
+            // Act
+            var data1 = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+            var data2 = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+            var data3 = await rawFileService.GetFileContentsAsync(configuration, "ScaleData.raw");
+
+            // Assert
+            ClassicAssert.AreEqual(data1, data2, "Multiple calls should return same data");
+            ClassicAssert.AreEqual(data2, data3, "Multiple calls should return same data");
+
+            // Cleanup
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        #endregion
+    }
+}

--- a/SimcProfileParser.Tests/SimcItemCreationServiceTests.cs
+++ b/SimcProfileParser.Tests/SimcItemCreationServiceTests.cs
@@ -41,7 +41,9 @@ namespace SimcProfileParser.Tests
 
             IRawDataExtractionService rawDataExtractionService =
                 new RawDataExtractionService(_loggerFactory.CreateLogger<RawDataExtractionService>());
-            ICacheService cacheService = new CacheService(rawDataExtractionService, _loggerFactory.CreateLogger<CacheService>());
+            ICacheService cacheService = new CacheService(rawDataExtractionService, 
+                _loggerFactory.CreateLogger<CacheService>(),
+                new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
             var utilityService = new SimcUtilityService(
                 cacheService,
                 _loggerFactory.CreateLogger<SimcUtilityService>());

--- a/SimcProfileParser.Tests/SimcSpellCreationServiceTests.cs
+++ b/SimcProfileParser.Tests/SimcSpellCreationServiceTests.cs
@@ -34,7 +34,9 @@ namespace SimcProfileParser.Tests
 
             IRawDataExtractionService rawDataExtractionService =
                 new RawDataExtractionService(_loggerFactory.CreateLogger<RawDataExtractionService>());
-            ICacheService cacheService = new CacheService(rawDataExtractionService, _loggerFactory.CreateLogger<CacheService>());
+            ICacheService cacheService = new CacheService(rawDataExtractionService, 
+                _loggerFactory.CreateLogger<CacheService>(), 
+                new RawFileService(_loggerFactory.CreateLogger<RawFileService>()));
             var utilityService = new SimcUtilityService(
                 cacheService,
                 _loggerFactory.CreateLogger<SimcUtilityService>());

--- a/SimcProfileParser/DataSync/RawFileService.cs
+++ b/SimcProfileParser/DataSync/RawFileService.cs
@@ -1,0 +1,343 @@
+﻿using Microsoft.Extensions.Logging;
+using SimcProfileParser.Interfaces.DataSync;
+using SimcProfileParser.Model.DataSync;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace SimcProfileParser.DataSync
+{
+    /// <summary>
+    /// The intent of this class is to manage access to the raw data files. 
+    /// </summary>
+    internal class RawFileService(ILogger<RawFileService> logger) : IRawFileService
+    {
+        private string BaseFileDirectory = Path.Combine(AppContext.BaseDirectory, "SimcDataCache");
+        private readonly string _rawFileCacheDataFile = "FileDownloadCache.json";
+        protected List<FileETag> _rawFileEtagCacheData = new();
+        private static readonly HttpClient downloadClient = new();
+
+        private readonly string rawDataFileExtension = "raw";
+        private bool usePtrData = false;
+        private string useBranchName = "midnight";
+        internal string _getUrl(string fileName) => "https://raw.githubusercontent.com/simulationcraft/simc/"
+                + useBranchName + "/engine/dbc/generated/"
+                + fileName
+                + (usePtrData ? "_ptr" : "")
+                + ".inc";
+
+        public async Task<string> GetFileContentsAsync(CacheFileConfiguration configuration, string localRawFile)
+        {
+            // Always: If we download a raw file or generate a.json file, we must update FileDownloadCache.json
+            // If it's been more than an hour since we last checked the ETag for a file,
+            //  when accessing in-memory processed data we should revalidate the associated raw file
+            // If a raw file needs to be validated, we do this by checking the file exists on disk still,
+            //  and it's stored ETag matches against the remote file using a head request
+
+            var localPath = Path.Combine(BaseFileDirectory, localRawFile);
+
+            var destinationRawFile = configuration.RawFiles.FirstOrDefault(r => r.Key == localRawFile);
+            var remoteFileUri = new Uri(_getUrl(destinationRawFile.Value));
+            var localFilePath = Path.Combine(BaseFileDirectory, destinationRawFile.Key);
+
+            var downloaded = await DownloadFileIfInvalidAsync(remoteFileUri, localFilePath);
+
+            if (!downloaded)
+            {
+                if(!File.Exists(localPath))
+                    throw new FileNotFoundException($"Failed to obtain raw file '{destinationRawFile.Key}'", localPath);
+
+                logger?.LogError("Unable to download [{destinationRawFile}] to [{localPath}]", destinationRawFile, localPath);
+                if (Directory.Exists(BaseFileDirectory))
+                {
+                    logger?.LogTrace("Listing directory contents for [{BaseFileDirectory}]", BaseFileDirectory);
+                    foreach (var file in Directory.GetFiles(BaseFileDirectory))
+                    {
+                        logger?.LogTrace("File: {file}", file);
+                    }
+                }
+                else
+                {
+                    logger?.LogError("Directory does not exist: [{BaseFileDirectory}]", BaseFileDirectory);
+                }
+            }
+
+            var data = await File.ReadAllTextAsync(localPath);
+
+            return data;
+        }
+
+        public async Task<bool> IsFileValidAsync(string remoteFile, string localFile)
+        {
+            var remoteUri = new Uri(_getUrl(remoteFile));
+            var localUri = Path.Combine(BaseFileDirectory, localFile);
+
+            return await IsFileValidAsync(remoteUri, localUri);
+        }
+
+        /// <summary>
+        /// A file is valid if it exists, and its etag has been checked within 
+        /// the last hour and matches the remote etag.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<bool> IsFileValidAsync(Uri remoteUri, string localUri)
+        {
+            // First, check if the file exists.
+            if (!File.Exists(localUri))
+                return false;
+
+            // Get the etag from the cache
+            var cachedEtag = _rawFileEtagCacheData.FirstOrDefault(e => e.Filename == localUri);
+
+            if (cachedEtag == null)
+            {
+                logger?.LogTrace("No etag found for {destinationUri.LocalPath}", localUri);
+                return false;
+            }
+            logger?.LogTrace("etag for this file is {eTag}", cachedEtag);
+
+            // Now, if we haven't checked in the last hour, check if the etag is valid.
+            if (cachedEtag.LastChecked <= DateTime.UtcNow.AddHours(-1))
+            {
+                var remoteEtag = await GetRemoteEtagAsync(remoteUri);
+
+                if (string.IsNullOrWhiteSpace(remoteEtag))
+                {
+                    logger?.LogTrace("No remote etag found for {sourceUri}", remoteUri);
+                    return false;
+                }
+
+                var valid = string.Equals(cachedEtag.ETag, remoteEtag, StringComparison.Ordinal);
+                logger?.LogTrace("File {destinationUri.LocalPath} etag valid: {valid}", localUri, valid);
+
+                if (valid)
+                {
+                    cachedEtag.LastChecked = DateTime.UtcNow;
+                    await SaveEtagDetailsToDiskAsync();
+                }
+
+                return valid;
+            }
+
+            logger?.LogTrace("File {destinationUri.LocalPath} exists and etag was checked recently.", localUri);
+            return true;
+        }
+
+        /// <summary>
+        /// Check if the local file exists and the cache matches
+        /// </summary>
+        internal async Task<bool> DownloadFileIfInvalidAsync(Uri remoteUri, string localUri)
+        {
+            // A file is invalid if:
+            // - It does not exist
+            // - The etag does not match
+            // The etag should be checked every LastChecked + 1 hour.
+            if(await IsFileValidAsync(remoteUri, localUri))
+            {
+                logger?.LogTrace("File {destinationUri.LocalPath} is valid, no download needed.", localUri);
+                return true;
+            }
+
+            // If we've reached this point, the local file is either missing or invalid.
+            var downloadResponse = await DownloadFileAsync(remoteUri, localUri);
+
+            // If the download was successful, save the etag.
+            if (downloadResponse)
+            {
+                logger?.LogTrace("Successfully downloaded {sourceUri} to {destinationUri.LocalPath}", remoteUri, localUri);
+
+                var remoteEtag = await GetRemoteEtagAsync(remoteUri);
+
+                await UpdateRawFileDetailsAsync(localUri, 
+                    remoteEtag, 
+                    File.GetLastWriteTimeUtc(localUri));
+            }
+            else
+            {
+                logger?.LogError("Failure downloading file.");
+            }
+
+            return downloadResponse;
+        }
+
+        private async Task<string> GetRemoteEtagAsync(Uri sourceUri)
+        {
+            HttpRequestMessage request =
+               new(HttpMethod.Head,
+                  sourceUri);
+
+            HttpResponseMessage response;
+
+            try
+            {
+                response = await downloadClient.SendAsync(request);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Error checking etag for {sourceUri}", sourceUri);
+                return string.Empty;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger?.LogError("Error checking etag for {sourceUri}. Status code: {StatusCode}", sourceUri, response.StatusCode);
+                return string.Empty;
+            }
+
+            var tag = response.Headers.ETag?.Tag;
+            if (string.IsNullOrWhiteSpace(tag))
+                return string.Empty;
+
+            logger?.LogTrace("ETag for {sourceUri} is {ETag}", sourceUri, tag);
+
+            return tag;
+        }
+
+        /// <summary>
+        /// Update the cache with an entry
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <param name="eTag"></param>
+        internal async Task UpdateRawFileDetailsAsync(string filename, string eTag, DateTime lastModified)
+        {
+            var existing = _rawFileEtagCacheData.FirstOrDefault(e => e.Filename == filename);
+
+            if (existing != null)
+            {
+                existing.ETag = eTag;
+                existing.LastModified = lastModified;
+                existing.LastChecked = DateTime.UtcNow;
+            }
+            else
+            {
+                _rawFileEtagCacheData.Add(new FileETag()
+                {
+                    Filename = filename,
+                    ETag = eTag,
+                    LastModified = lastModified,
+                    LastChecked = DateTime.UtcNow
+                });
+            }
+
+            await SaveEtagDetailsToDiskAsync();
+        }
+
+        /// <summary>
+        /// Load the cached etag data from file
+        /// </summary>
+        internal async Task<List<FileETag>> GetCacheDataAsync()
+        {
+            var results = new List<FileETag>();
+            var cacheDataFile = Path.Combine(BaseFileDirectory, _rawFileCacheDataFile);
+
+            if (File.Exists(cacheDataFile))
+            {
+                var data = await File.ReadAllTextAsync(cacheDataFile);
+
+                var deserialised = JsonSerializer.Deserialize<List<FileETag>>(data);
+
+                if (deserialised != null)
+                    results = deserialised;
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Save the cached etag data to file. Do this each time an update is made.
+        /// </summary>
+        internal async Task SaveEtagDetailsToDiskAsync()
+        {
+            var baseDirectory = new Uri(BaseFileDirectory);
+            if (!Directory.Exists(baseDirectory.LocalPath))
+                Directory.CreateDirectory(baseDirectory.LocalPath);
+
+            var cacheDataFile = Path.Combine(BaseFileDirectory, _rawFileCacheDataFile);
+            var dataString = JsonSerializer.Serialize(_rawFileEtagCacheData, new JsonSerializerOptions { WriteIndented = true });
+
+            await File.WriteAllTextAsync(cacheDataFile, dataString);
+        }
+
+        /// <summary>
+        /// Configures the base directory used for file operations.
+        /// </summary>
+        /// <param name="baseFileDirectory">The path to the directory that will be set as the base for file operations. Cannot be null.</param>
+        public async Task ConfigureAsync(string baseFileDirectory)
+        {
+            BaseFileDirectory = baseFileDirectory;
+            _rawFileEtagCacheData = await GetCacheDataAsync();
+        }
+
+        public async Task DeleteAllFiles()
+        {
+            _rawFileEtagCacheData.Clear();
+            await SaveEtagDetailsToDiskAsync();
+            try
+            {
+                if (Directory.Exists(BaseFileDirectory))
+                {
+                    foreach (var file in Directory.GetFiles(BaseFileDirectory, $"*.{rawDataFileExtension}"))
+                    {
+                        try 
+                        { 
+                            File.Delete(file); 
+                        }
+                        catch (Exception ex)
+                        {
+                            logger?.LogWarning(ex, "Failed to delete cache file {file}", file);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Error clearing cache directory {BaseFileDirectory}", BaseFileDirectory);
+            }
+        }
+
+        /// <summary>
+        /// Download a file from sourceUri to destinationUri, overwriting if it exists.
+        /// </summary>
+        /// <returns></returns>
+        internal async Task<bool> DownloadFileAsync(Uri sourceUri, string destinationFile)
+        {
+            try
+            {
+                if (!Directory.Exists(BaseFileDirectory))
+                    Directory.CreateDirectory(BaseFileDirectory);
+
+                using var s = await downloadClient.GetStreamAsync(sourceUri);
+
+                if (File.Exists(destinationFile))
+                    File.Delete(destinationFile);
+
+                using var fs = new FileStream(destinationFile, FileMode.CreateNew);
+                await s.CopyToAsync(fs);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Unable to DownloadFileAsync [{sourceUri}] to [{destinationUri}]", sourceUri, destinationFile);
+                return false;
+            }
+            return true;
+        }
+
+
+        /// <summary>
+        /// Get the flag used PTR data for data extraction
+        /// </summary>
+        public bool UsePtrData { get => usePtrData; }
+        public void SetUsePtrData(bool usePtrData) => this.usePtrData = usePtrData;
+
+        /// <summary>
+        /// Get the github branch name used for data extraction
+        /// </summary>
+        public string UseBranchName { get => useBranchName; }
+        public void SetUseBranchName(string branchName) => useBranchName = branchName;
+    }
+}

--- a/SimcProfileParser/Interfaces/DataSync/ICacheService.cs
+++ b/SimcProfileParser/Interfaces/DataSync/ICacheService.cs
@@ -1,5 +1,4 @@
 ﻿using SimcProfileParser.Model.DataSync;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace SimcProfileParser.Interfaces.DataSync
@@ -13,16 +12,6 @@ namespace SimcProfileParser.Interfaces.DataSync
         /// The base directory the cache service stores its files
         /// </summary>
         string BaseFileDirectory { get; }
-        /// <summary>
-        /// Collection of already registered file configurations
-        /// </summary>
-        IReadOnlyCollection<CacheFileConfiguration> RegisteredFiles { get; }
-
-        /// <summary>
-        /// Register a configuration representing a parsed json file and its raw sources
-        /// </summary>
-        /// <param name="configuration"></param>
-        void RegisterFileConfiguration(CacheFileConfiguration configuration);
 
         /// <summary>
         /// Get back the parsed file contents from disk
@@ -31,12 +20,6 @@ namespace SimcProfileParser.Interfaces.DataSync
         /// <param name="fileType">Type of parsed file to return</param>
         /// <returns></returns>
         Task<T> GetParsedFileContentsAsync<T>(SimcParsedFileType fileType);
-        /// <summary>
-        /// Generates a version of the raw files that's stored as parsed.json data which can be
-        /// used by GetParsedFileContents to extract the parsed data as objects
-        /// </summary>
-        /// <param name="fileType">The type of file this should generate</param>
-        Task GenerateParsedFileAsync(SimcParsedFileType fileType);
 
         /// <summary>
         /// Set to TRUE to use PTR data for data extraction

--- a/SimcProfileParser/Interfaces/DataSync/IRawFileService.cs
+++ b/SimcProfileParser/Interfaces/DataSync/IRawFileService.cs
@@ -1,0 +1,19 @@
+﻿using SimcProfileParser.Model.DataSync;
+using System;
+using System.Threading.Tasks;
+
+namespace SimcProfileParser.Interfaces.DataSync
+{
+    internal interface IRawFileService
+    {
+        bool UsePtrData { get; }
+        string UseBranchName { get; }
+
+        Task DeleteAllFiles();
+        Task ConfigureAsync(string baseFileDirectory);
+        Task<string> GetFileContentsAsync(CacheFileConfiguration configuration, string localRawFile);
+        void SetUsePtrData(bool usePtrData);
+        void SetUseBranchName(string branchName);
+        Task<bool> IsFileValidAsync(string remoteFile, string destinationFile);
+    }
+}

--- a/SimcProfileParser/Model/DataSync/FileETag.cs
+++ b/SimcProfileParser/Model/DataSync/FileETag.cs
@@ -7,5 +7,6 @@ namespace SimcProfileParser.Model.DataSync
         public string Filename { get; set; }
         public string ETag { get; set; }
         public DateTime LastModified { get; set; }
+        public DateTime LastChecked { get; set; }
     }
 }

--- a/SimcProfileParser/SimcGenerationService.cs
+++ b/SimcProfileParser/SimcGenerationService.cs
@@ -82,7 +82,8 @@ namespace SimcProfileParser
                 loggerFactory.CreateLogger<RawDataExtractionService>());
 
             _cacheService = new CacheService(dataExtractionService,
-                loggerFactory.CreateLogger<CacheService>());
+                loggerFactory.CreateLogger<CacheService>(),
+                new RawFileService(loggerFactory.CreateLogger<RawFileService>()));
 
             var utilityService = new SimcUtilityService(
                 _cacheService,

--- a/SimcProfileParser/SimcProfileParser.csproj
+++ b/SimcProfileParser/SimcProfileParser.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.1.2</Version>
-	<AssemblyVersion>3.1.2</AssemblyVersion>
-	<FileVersion>3.1.2</FileVersion>
+    <Version>3.2.0</Version>
+	<AssemblyVersion>3.2.0</AssemblyVersion>
+	<FileVersion>3.2.0</FileVersion>
 	<Authors>Mechanical Priest</Authors>
 	<Company>Mechanical Priest</Company>
 	<PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>


### PR DESCRIPTION
This pull request refactors the `CacheService` and related test initialisation to improve dependency management and cache validation logic. The main changes include injecting the new `RawFileService` dependency.

### Dependency Injection and Initialisation

* Added `RawFileService` as a dependency to `CacheService`, updating its constructor and test initialisations to support this change.
* Changed protected member initialisations in `CacheService` from explicit constructors to collection initialisers for `_registeredFiles` and `_cachedFileData`.
* Refactored cache file registration in `CacheService` to use the direct `RegisterFileConfiguration` method instead of casting to the interface.
* Improved cache validation in `GetParsedFileContentsAsync` by checking disk cache validity and removing invalid files before loading new data.